### PR TITLE
feat: leaderboard with display name consent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ dist/
 app.json.log
 .DS_Store
 .next/
+.superpowers/
 docs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# PetBot Project Guidelines
+
+## Commit Conventions
+
+- Never add `Co-Authored-By` or any Claude/anthropic attribution to commits.
+- Commit messages should be concise and describe the change, not the process.
+- Follow the existing commit style: `type: brief description` (e.g., `feat:`, `fix:`, `chore:`).

--- a/apps/web/app/api/leaderboard-consent/route.ts
+++ b/apps/web/app/api/leaderboard-consent/route.ts
@@ -1,0 +1,54 @@
+import { requireSession } from "../../../lib/auth";
+import { proxyRequest } from "../../../lib/proxy";
+import { createHash } from "node:crypto";
+
+function hashUserId(userId: string): string {
+  return createHash("sha256").update(userId).digest("hex").slice(0, 6);
+}
+
+export async function GET(req: Request) {
+  try {
+    const session = requireSession(req);
+    const userId = session.user!.id!;
+    const hashed = hashUserId(userId);
+    const res = await proxyRequest(
+      `/api/leaderboardConsent/${encodeURIComponent(hashed)}`,
+    );
+    const json = (await res.json()) as { enabled: boolean; displayName: string | null };
+    return Response.json({ ...json, hashLabel: `User #${hashed}` });
+  } catch (res) {
+    if (res instanceof Response) return res;
+    throw res;
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const session = requireSession(req);
+    const userId = session.user!.id!;
+    const hashed = hashUserId(userId);
+    const body = (await req.json()) as { displayName?: string };
+    return proxyRequest(
+      `/api/leaderboardConsent/${encodeURIComponent(hashed)}`,
+      { method: "POST", body },
+    );
+  } catch (res) {
+    if (res instanceof Response) return res;
+    throw res;
+  }
+}
+
+export async function DELETE(req: Request) {
+  try {
+    const session = requireSession(req);
+    const userId = session.user!.id!;
+    const hashed = hashUserId(userId);
+    return proxyRequest(
+      `/api/leaderboardConsent/${encodeURIComponent(hashed)}`,
+      { method: "DELETE" },
+    );
+  } catch (res) {
+    if (res instanceof Response) return res;
+    throw res;
+  }
+}

--- a/apps/web/app/api/leaderboard-consent/route.ts
+++ b/apps/web/app/api/leaderboard-consent/route.ts
@@ -3,7 +3,7 @@ import { proxyRequest } from "../../../lib/proxy";
 import { createHash } from "node:crypto";
 
 function hashUserId(userId: string): string {
-  return createHash("sha256").update(userId).digest("hex").slice(0, 6);
+  return createHash("sha256").update(userId).digest("hex").slice(0, 16);
 }
 
 export async function GET(req: Request) {
@@ -15,7 +15,7 @@ export async function GET(req: Request) {
       `/api/leaderboardConsent/${encodeURIComponent(hashed)}`,
     );
     const json = (await res.json()) as { enabled: boolean; displayName: string | null };
-    return Response.json({ ...json, hashLabel: `User #${hashed}` });
+    return Response.json({ ...json, hashLabel: `User #${hashed.slice(0, 6)}` });
   } catch (res) {
     if (res instanceof Response) return res;
     throw res;

--- a/apps/web/app/api/leaderboard/route.ts
+++ b/apps/web/app/api/leaderboard/route.ts
@@ -1,16 +1,16 @@
 import { requireSession, resolveGuilds } from "../../../lib/auth";
-import { proxyRequest } from "../../../lib/proxy";
+import { getInternalApiBase, internalApiHeadersOptional } from "../../../lib/internal-api";
 import { apiError } from "../../../lib/errors";
 
 export async function GET(req: Request) {
   try {
     const session = requireSession(req);
+    const currentUserId = session.user!.id!;
     const url = new URL(req.url);
     const locationId = url.searchParams.get("locationId");
     const actionType = url.searchParams.get("actionType");
     const limit = url.searchParams.get("limit") ?? "10";
 
-    // If locationId is provided and looks like a guild ID, check membership
     if (locationId && /^\d+$/.test(locationId)) {
       const guilds = await resolveGuilds(session);
       if (!guilds.some((g) => g.id === locationId)) {
@@ -19,18 +19,42 @@ export async function GET(req: Request) {
     }
 
     const params = new URLSearchParams({ limit });
-    if (locationId) {
-      params.set("locationId", locationId);
-    }
-    if (actionType) {
-      params.set("actionType", actionType);
+    if (locationId) params.set("locationId", locationId);
+    if (actionType) params.set("actionType", actionType);
+    params.set("currentUserId", currentUserId);
+
+    const base = getInternalApiBase();
+    const res = await fetch(`${base}/api/leaderboard?${params.toString()}`, {
+      headers: internalApiHeadersOptional(),
+    });
+
+    if (!res.ok) {
+      return Response.json(
+        await res.json().catch(() => ({ error: "upstream_error" })),
+        { status: res.status },
+      );
     }
 
-    return proxyRequest(`/api/leaderboard?${params.toString()}`);
+    const data = await res.json() as {
+      locationId: string | null;
+      actionType: string | null;
+      entries: Array<{
+        rank: number;
+        userId: string;
+        displayName: string | null;
+        anonymousLabel: string;
+        totalActions: number;
+      }>;
+    };
+
+    const entries = data.entries.map(({ userId, ...entry }) => ({
+      ...entry,
+      isCurrentUser: userId === currentUserId,
+    }));
+
+    return Response.json({ ...data, entries });
   } catch (res) {
-    if (res instanceof Response) {
-      return res;
-    }
+    if (res instanceof Response) return res;
     throw res;
   }
 }

--- a/apps/web/app/api/leaderboard/route.ts
+++ b/apps/web/app/api/leaderboard/route.ts
@@ -10,19 +10,18 @@ export async function GET(req: Request) {
     const actionType = url.searchParams.get("actionType");
     const limit = url.searchParams.get("limit") ?? "10";
 
-    if (!locationId) {
-      throw apiError(400, "missing_locationId");
-    }
-
-    // If locationId looks like a guild ID (all digits), check guild membership
-    if (/^\d+$/.test(locationId)) {
+    // If locationId is provided and looks like a guild ID, check membership
+    if (locationId && /^\d+$/.test(locationId)) {
       const guilds = await resolveGuilds(session);
       if (!guilds.some((g) => g.id === locationId)) {
         throw apiError(403, "forbidden");
       }
     }
 
-    const params = new URLSearchParams({ locationId, limit });
+    const params = new URLSearchParams({ limit });
+    if (locationId) {
+      params.set("locationId", locationId);
+    }
     if (actionType) {
       params.set("actionType", actionType);
     }

--- a/apps/web/app/api/leaderboard/route.ts
+++ b/apps/web/app/api/leaderboard/route.ts
@@ -11,7 +11,9 @@ export async function GET(req: Request) {
     const actionType = url.searchParams.get("actionType");
     const limit = url.searchParams.get("limit") ?? "10";
 
-    if (locationId && /^\d+$/.test(locationId)) {
+    const scope = url.searchParams.get("scope");
+
+    if (scope === "guild" && locationId) {
       const guilds = await resolveGuilds(session);
       if (!guilds.some((g) => g.id === locationId)) {
         throw apiError(403, "forbidden");

--- a/apps/web/app/api/leaderboard/route.ts
+++ b/apps/web/app/api/leaderboard/route.ts
@@ -1,0 +1,37 @@
+import { requireSession, resolveGuilds } from "../../../lib/auth";
+import { proxyRequest } from "../../../lib/proxy";
+import { apiError } from "../../../lib/errors";
+
+export async function GET(req: Request) {
+  try {
+    const session = requireSession(req);
+    const url = new URL(req.url);
+    const locationId = url.searchParams.get("locationId");
+    const actionType = url.searchParams.get("actionType");
+    const limit = url.searchParams.get("limit") ?? "10";
+
+    if (!locationId) {
+      throw apiError(400, "missing_locationId");
+    }
+
+    // If locationId looks like a guild ID (all digits), check guild membership
+    if (/^\d+$/.test(locationId)) {
+      const guilds = await resolveGuilds(session);
+      if (!guilds.some((g) => g.id === locationId)) {
+        throw apiError(403, "forbidden");
+      }
+    }
+
+    const params = new URLSearchParams({ locationId, limit });
+    if (actionType) {
+      params.set("actionType", actionType);
+    }
+
+    return proxyRequest(`/api/leaderboard?${params.toString()}`);
+  } catch (res) {
+    if (res instanceof Response) {
+      return res;
+    }
+    throw res;
+  }
+}

--- a/apps/web/app/dmStats/[locationId]/page.tsx
+++ b/apps/web/app/dmStats/[locationId]/page.tsx
@@ -279,7 +279,7 @@ export default function DmStatsLocationPage({
         <Leaderboard
           locationId={locationId}
           actionType={hoveredAction}
-          className="w-72 flex-shrink-0 hidden lg:block"
+          className="w-80 flex-shrink-0 hidden lg:block"
         />
       </div>
 

--- a/apps/web/app/dmStats/[locationId]/page.tsx
+++ b/apps/web/app/dmStats/[locationId]/page.tsx
@@ -233,9 +233,9 @@ export default function DmStatsLocationPage({
 
   return (
     <main>
-      <div className="flex gap-6">
+      <div className="grid gap-4 grid-cols-4">
         {/* Left: stats */}
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0 col-span-4 xl:col-span-3">
           <div
             className={`flex flex-col gap-4 ${isLoading ? "opacity-80" : ""}`}
             aria-busy={isLoading}
@@ -279,13 +279,8 @@ export default function DmStatsLocationPage({
         <Leaderboard
           locationId={locationId}
           actionType={hoveredAction}
-          className="w-80 flex-shrink-0 hidden lg:block"
+          className="col-span-4 xl:col-span-1"
         />
-      </div>
-
-      {/* Leaderboard below on mobile */}
-      <div className="lg:hidden mt-4">
-        <Leaderboard locationId={locationId} actionType={hoveredAction} />
       </div>
     </main>
   );

--- a/apps/web/app/dmStats/[locationId]/page.tsx
+++ b/apps/web/app/dmStats/[locationId]/page.tsx
@@ -9,6 +9,7 @@ import StatsCard from "@/components/stats/stats-card";
 import StatsCardSimple from "@/components/stats/stats-card-simple";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import Leaderboard from "@/components/leaderboard";
 
 export default function DmStatsLocationPage({
   params,
@@ -48,6 +49,8 @@ export default function DmStatsLocationPage({
     locationId,
     userId: session?.user.id ?? null,
   });
+
+  const [hoveredAction, setHoveredAction] = React.useState<string | null>(null);
 
   const submitLocation = React.useCallback(
     (e?: React.FormEvent) => {
@@ -230,41 +233,60 @@ export default function DmStatsLocationPage({
 
   return (
     <main>
-      <div
-        className={`flex flex-col gap-4 ${isLoading ? "opacity-80" : ""}`}
-        aria-busy={isLoading}
-      >
-        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
-          <StatsCardSimple
-            statString="Total Actions Performed"
-            value={data.totalActionsPerformed}
-          />
-          <StatsCardSimple
-            statString="Total Unique Users"
-            value={data.totalUniqueUsers}
-          />
+      <div className="flex gap-6">
+        {/* Left: stats */}
+        <div className="flex-1 min-w-0">
+          <div
+            className={`flex flex-col gap-4 ${isLoading ? "opacity-80" : ""}`}
+            aria-busy={isLoading}
+          >
+            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
+              <StatsCardSimple
+                statString="Total Actions Performed"
+                value={data.totalActionsPerformed}
+              />
+              <StatsCardSimple
+                statString="Total Unique Users"
+                value={data.totalUniqueUsers}
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {entries.map(([actionKey, totals]) => (
+                <StatsCard
+                  key={actionKey}
+                  actionName={actionKey}
+                  actionImageUrl={totals.imageUrl}
+                  performedCount={totals.totalHasPerformed}
+                  userCount={totals.totalUsers}
+                  totalUniqueUsers={data.totalUniqueUsers}
+                  totalActionsPerformed={data.totalActionsPerformed}
+                  onMouseEnter={() => setHoveredAction(actionKey)}
+                  onMouseLeave={() => setHoveredAction(null)}
+                />
+              ))}
+            </div>
+          </div>
+
+          {error ? (
+            <div className="mt-4 text-sm text-destructive">
+              Failed to load stats: {error.message}
+            </div>
+          ) : null}
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {entries.map(([actionKey, totals]) => (
-            <StatsCard
-              key={actionKey}
-              actionName={actionKey}
-              actionImageUrl={totals.imageUrl}
-              performedCount={totals.totalHasPerformed}
-              userCount={totals.totalUsers}
-              totalUniqueUsers={data.totalUniqueUsers}
-              totalActionsPerformed={data.totalActionsPerformed}
-            />
-          ))}
-        </div>
+        {/* Right: leaderboard (desktop) */}
+        <Leaderboard
+          locationId={locationId}
+          actionType={hoveredAction}
+          className="w-72 flex-shrink-0 hidden lg:block"
+        />
       </div>
 
-      {error ? (
-        <div className="mt-4 text-sm text-destructive">
-          Failed to load stats: {error.message}
-        </div>
-      ) : null}
+      {/* Leaderboard below on mobile */}
+      <div className="lg:hidden mt-4">
+        <Leaderboard locationId={locationId} actionType={hoveredAction} />
+      </div>
     </main>
   );
 }

--- a/apps/web/app/globalStats/page.tsx
+++ b/apps/web/app/globalStats/page.tsx
@@ -26,9 +26,9 @@ export default function GlobalStatsPage() {
           Loading global stats…
         </p>
       ) : (
-        <div className="flex gap-6">
+        <div className="grid gap-4 grid-cols-4">
           {/* Left: stats */}
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0 col-span-4 xl:col-span-3">
             <div className="flex flex-col gap-4">
               <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3">
                 <StatsCardSimple
@@ -66,15 +66,10 @@ export default function GlobalStatsPage() {
           <Leaderboard
             locationId={null}
             actionType={hoveredAction}
-            className="w-80 flex-shrink-0 hidden lg:block"
+            className="col-span-4 xl:col-span-1"
           />
         </div>
       )}
-
-      {/* Leaderboard below on mobile */}
-      <div className="lg:hidden mt-4">
-        <Leaderboard locationId={null} actionType={hoveredAction} />
-      </div>
 
       {error ? (
         <div className="mt-4 text-sm text-destructive">

--- a/apps/web/app/globalStats/page.tsx
+++ b/apps/web/app/globalStats/page.tsx
@@ -5,6 +5,7 @@ import { useGlobalStats } from "@/hooks/use-global-stats";
 import StatsCard from "@/components/stats/stats-card";
 import { ActionTotals } from "@/types/stats";
 import StatsCardSimple from "@/components/stats/stats-card-simple";
+import Leaderboard from "@/components/leaderboard";
 
 export default function GlobalStatsPage() {
   const { data, isLoading, error, refresh } = useGlobalStats();
@@ -24,36 +25,53 @@ export default function GlobalStatsPage() {
           Loading global stats…
         </p>
       ) : (
-        <div className="flex flex-col gap-4">
-          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3">
-            <StatsCardSimple
-              statString="Total Actions Performed"
-              value={data.totalActionsPerformed}
-            />
-            <StatsCardSimple
-              statString="Total Unique Users"
-              value={data.totalUniqueUsers}
-            />
-            <StatsCardSimple
-              statString="Total Visited Locations"
-              value={data.totalLocations}
-            />
+        <div className="flex gap-6">
+          {/* Left: stats */}
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-col gap-4">
+              <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3">
+                <StatsCardSimple
+                  statString="Total Actions Performed"
+                  value={data.totalActionsPerformed}
+                />
+                <StatsCardSimple
+                  statString="Total Unique Users"
+                  value={data.totalUniqueUsers}
+                />
+                <StatsCardSimple
+                  statString="Total Visited Locations"
+                  value={data.totalLocations}
+                />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {entries.map(([actionKey, totals]) => (
+                  <StatsCard
+                    key={actionKey}
+                    actionName={actionKey}
+                    actionImageUrl={totals.imageUrl}
+                    performedCount={totals.totalHasPerformed}
+                    userCount={totals.totalUsers}
+                    totalUniqueUsers={data.totalUniqueUsers}
+                    totalActionsPerformed={data.totalActionsPerformed}
+                  />
+                ))}
+              </div>
+            </div>
           </div>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {entries.map(([actionKey, totals]) => (
-              <StatsCard
-                key={actionKey}
-                actionName={actionKey}
-                actionImageUrl={totals.imageUrl}
-                performedCount={totals.totalHasPerformed}
-                userCount={totals.totalUsers}
-                totalUniqueUsers={data.totalUniqueUsers}
-                totalActionsPerformed={data.totalActionsPerformed}
-              />
-            ))}
-          </div>
+
+          {/* Right: leaderboard (desktop) */}
+          <Leaderboard
+            locationId={null}
+            actionType={null}
+            className="w-72 flex-shrink-0 hidden lg:block"
+          />
         </div>
       )}
+
+      {/* Leaderboard below on mobile */}
+      <div className="lg:hidden mt-4">
+        <Leaderboard locationId={null} actionType={null} />
+      </div>
 
       {error ? (
         <div className="mt-4 text-sm text-destructive">

--- a/apps/web/app/globalStats/page.tsx
+++ b/apps/web/app/globalStats/page.tsx
@@ -9,6 +9,7 @@ import Leaderboard from "@/components/leaderboard";
 
 export default function GlobalStatsPage() {
   const { data, isLoading, error, refresh } = useGlobalStats();
+  const [hoveredAction, setHoveredAction] = React.useState<string | null>(null);
 
   if (!data) {
     return <p className="mt-4 text-sm text-muted-foreground">No data</p>;
@@ -53,6 +54,8 @@ export default function GlobalStatsPage() {
                     userCount={totals.totalUsers}
                     totalUniqueUsers={data.totalUniqueUsers}
                     totalActionsPerformed={data.totalActionsPerformed}
+                    onMouseEnter={() => setHoveredAction(actionKey)}
+                    onMouseLeave={() => setHoveredAction(null)}
                   />
                 ))}
               </div>
@@ -62,7 +65,7 @@ export default function GlobalStatsPage() {
           {/* Right: leaderboard (desktop) */}
           <Leaderboard
             locationId={null}
-            actionType={null}
+            actionType={hoveredAction}
             className="w-72 flex-shrink-0 hidden lg:block"
           />
         </div>
@@ -70,7 +73,7 @@ export default function GlobalStatsPage() {
 
       {/* Leaderboard below on mobile */}
       <div className="lg:hidden mt-4">
-        <Leaderboard locationId={null} actionType={null} />
+        <Leaderboard locationId={null} actionType={hoveredAction} />
       </div>
 
       {error ? (

--- a/apps/web/app/globalStats/page.tsx
+++ b/apps/web/app/globalStats/page.tsx
@@ -66,7 +66,7 @@ export default function GlobalStatsPage() {
           <Leaderboard
             locationId={null}
             actionType={hoveredAction}
-            className="w-72 flex-shrink-0 hidden lg:block"
+            className="w-80 flex-shrink-0 hidden lg:block"
           />
         </div>
       )}

--- a/apps/web/app/guildStats/[guildId]/page.tsx
+++ b/apps/web/app/guildStats/[guildId]/page.tsx
@@ -112,7 +112,7 @@ export default function GuildStatsPage({
         <Leaderboard
           locationId={guildId}
           actionType={hoveredAction}
-          className="w-72 flex-shrink-0 hidden lg:block"
+          className="w-80 flex-shrink-0 hidden lg:block"
         />
       </div>
 

--- a/apps/web/app/guildStats/[guildId]/page.tsx
+++ b/apps/web/app/guildStats/[guildId]/page.tsx
@@ -113,6 +113,7 @@ export default function GuildStatsPage({
           locationId={guildId}
           actionType={hoveredAction}
           className="col-span-4 xl:col-span-1"
+          context="guild"
         />
       </div>
     </main>

--- a/apps/web/app/guildStats/[guildId]/page.tsx
+++ b/apps/web/app/guildStats/[guildId]/page.tsx
@@ -8,6 +8,7 @@ import { type ActionTotals } from "@/types/stats";
 import { useBotGuilds } from "@/hooks/use-bot-guilds";
 import StatsCard from "@/components/stats/stats-card";
 import StatsCardSimple from "@/components/stats/stats-card-simple";
+import Leaderboard from "@/components/leaderboard";
 
 export default function GuildStatsPage({
   params,
@@ -47,6 +48,8 @@ export default function GuildStatsPage({
     guildId,
   });
 
+  const [hoveredAction, setHoveredAction] = React.useState<string | null>(null);
+
   // Handle loading and no-data states via JSX ternary (not early return)
   // so users see "Loading..." instead of "No data" on initial load
   if (!data) {
@@ -63,41 +66,60 @@ export default function GuildStatsPage({
 
   return (
     <main>
-      <div
-        className={`flex flex-col gap-4 ${isLoading ? "opacity-80" : ""}`}
-        aria-busy={isLoading}
-      >
-        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
-          <StatsCardSimple
-            statString="Total Actions Performed"
-            value={data.totalActionsPerformed}
-          />
-          <StatsCardSimple
-            statString="Total Unique Users"
-            value={data.totalUniqueUsers}
-          />
+      <div className="flex gap-6">
+        {/* Left: stats */}
+        <div className="flex-1 min-w-0">
+          <div
+            className={`flex flex-col gap-4 ${isLoading ? "opacity-80" : ""}`}
+            aria-busy={isLoading}
+          >
+            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
+              <StatsCardSimple
+                statString="Total Actions Performed"
+                value={data.totalActionsPerformed}
+              />
+              <StatsCardSimple
+                statString="Total Unique Users"
+                value={data.totalUniqueUsers}
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {entries.map(([actionKey, totals]) => (
+                <StatsCard
+                  key={actionKey}
+                  actionName={actionKey}
+                  actionImageUrl={totals.imageUrl}
+                  performedCount={totals.totalHasPerformed}
+                  userCount={totals.totalUsers}
+                  totalUniqueUsers={data.totalUniqueUsers}
+                  totalActionsPerformed={data.totalActionsPerformed}
+                  onMouseEnter={() => setHoveredAction(actionKey)}
+                  onMouseLeave={() => setHoveredAction(null)}
+                />
+              ))}
+            </div>
+          </div>
+
+          {error ? (
+            <div className="mt-4 text-sm text-destructive">
+              Failed to load stats: {error.message}
+            </div>
+          ) : null}
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {entries.map(([actionKey, totals]) => (
-            <StatsCard
-              key={actionKey}
-              actionName={actionKey}
-              actionImageUrl={totals.imageUrl}
-              performedCount={totals.totalHasPerformed}
-              userCount={totals.totalUsers}
-              totalUniqueUsers={data.totalUniqueUsers}
-              totalActionsPerformed={data.totalActionsPerformed}
-            />
-          ))}
-        </div>
+        {/* Right: leaderboard (desktop) */}
+        <Leaderboard
+          locationId={guildId}
+          actionType={hoveredAction}
+          className="w-72 flex-shrink-0 hidden lg:block"
+        />
       </div>
 
-      {error ? (
-        <div className="mt-4 text-sm text-destructive">
-          Failed to load stats: {error.message}
-        </div>
-      ) : null}
+      {/* Leaderboard below on mobile */}
+      <div className="lg:hidden mt-4">
+        <Leaderboard locationId={guildId} actionType={hoveredAction} />
+      </div>
     </main>
   );
 }

--- a/apps/web/app/guildStats/[guildId]/page.tsx
+++ b/apps/web/app/guildStats/[guildId]/page.tsx
@@ -66,9 +66,9 @@ export default function GuildStatsPage({
 
   return (
     <main>
-      <div className="flex gap-6">
+      <div className="grid gap-4 grid-cols-4">
         {/* Left: stats */}
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0 col-span-4 xl:col-span-3">
           <div
             className={`flex flex-col gap-4 ${isLoading ? "opacity-80" : ""}`}
             aria-busy={isLoading}
@@ -112,13 +112,8 @@ export default function GuildStatsPage({
         <Leaderboard
           locationId={guildId}
           actionType={hoveredAction}
-          className="w-80 flex-shrink-0 hidden lg:block"
+          className="col-span-4 xl:col-span-1"
         />
-      </div>
-
-      {/* Leaderboard below on mobile */}
-      <div className="lg:hidden mt-4">
-        <Leaderboard locationId={guildId} actionType={hoveredAction} />
       </div>
     </main>
   );

--- a/apps/web/components/dialogs/user-settings-dialog.tsx
+++ b/apps/web/components/dialogs/user-settings-dialog.tsx
@@ -18,6 +18,8 @@ import {
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
 import { Separator } from "../ui/separator";
+import { useLeaderboardConsent } from "@/hooks/use-leaderboard-consent";
+import { Switch } from "../ui/switch";
 
 export function UserSettingsDialog({
   open,
@@ -36,16 +38,44 @@ export function UserSettingsDialog({
     fetchStatus,
     toggle,
   } = useOptOut();
+  const {
+    enabled: consentEnabled,
+    displayName: consentDisplayName,
+    hashLabel,
+    isLoading: consentLoading,
+    fetchStatus: fetchConsent,
+    update: updateConsent,
+    disable: disableConsent,
+  } = useLeaderboardConsent();
   const [typedId, setTypedId] = useState("");
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [finalText, setFinalText] = useState("");
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [leaderboardName, setLeaderboardName] = useState("");
+  const [leaderboardNameTouched, setLeaderboardNameTouched] = useState(false);
+
+  const saveLeaderboardName = async (name: string) => {
+    const trimmed = name.trim();
+    if (trimmed.length === 0) return;
+    await updateConsent(trimmed);
+  };
 
   useEffect(() => {
-    if (open) void fetchStatus();
-  }, [open, fetchStatus]);
+    if (!leaderboardNameTouched) {
+      setLeaderboardName(
+        consentDisplayName ?? session?.user.username ?? ""
+      );
+    }
+  }, [consentDisplayName, session?.user.username, leaderboardNameTouched]);
+
+  useEffect(() => {
+    if (open) {
+      void fetchStatus();
+      void fetchConsent();
+    }
+  }, [open, fetchStatus, fetchConsent]);
 
   // load initial opt-out state when dialog opens
   const handleDeleteClick = () => {
@@ -111,6 +141,60 @@ export function UserSettingsDialog({
                   {optOutError.message}
                 </p>
               )}
+            </FieldSet>
+          </FieldGroup>
+          <Separator />
+          <FieldGroup className="px-6">
+            <FieldSet>
+              <FieldLegend>Leaderboard Display</FieldLegend>
+              <FieldDescription>
+                Choose how your name appears on leaderboards. When disabled,
+                you&apos;ll appear anonymously.
+              </FieldDescription>
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium">
+                  Show my name on leaderboards
+                </label>
+                <Switch
+                  checked={consentEnabled === true}
+                  onCheckedChange={async (checked) => {
+                    if (checked) {
+                      const name = leaderboardName || session?.user.username || "";
+                      setLeaderboardName(name);
+                      await updateConsent(name);
+                    } else {
+                      await disableConsent();
+                    }
+                  }}
+                  disabled={consentEnabled === null || consentLoading}
+                />
+              </div>
+              <Field>
+                <Input
+                  type="text"
+                  placeholder="Display name"
+                  value={
+                    consentEnabled
+                      ? leaderboardName
+                      : (hashLabel ?? "")
+                  }
+                  disabled={!consentEnabled || consentLoading}
+                  onChange={(e) => {
+                    setLeaderboardName(e.target.value);
+                    setLeaderboardNameTouched(true);
+                  }}
+                  onBlur={(e) => {
+                    if (consentEnabled) {
+                      void saveLeaderboardName(e.target.value);
+                    }
+                  }}
+                />
+                {consentEnabled && (
+                  <FieldDescription>
+                    Defaults to your Discord username
+                  </FieldDescription>
+                )}
+              </Field>
             </FieldSet>
           </FieldGroup>
           <Separator />

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -96,7 +96,7 @@ export default function Leaderboard({
                   className={cn(
                     "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
                     responsiveClass(i),
-                    isCurrentUser && "bg-accent",
+                    isCurrentUser && "bg-amber-500/10",
                   )}
                 >
                   <span className="w-5 text-center">
@@ -115,7 +115,7 @@ export default function Leaderboard({
                   <span
                     className={cn(
                       "flex-1 truncate",
-                      isCurrentUser && "font-medium",
+                      isCurrentUser && "font-medium text-amber-500",
                     )}
                   >
                     {label}

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -3,8 +3,7 @@
 import { useSession } from "@/hooks/use-session";
 import { useLeaderboard } from "@/hooks/use-leaderboard";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
+
 import {
   Card,
   CardHeader,
@@ -22,7 +21,7 @@ interface LeaderboardProps {
   className?: string;
 }
 
-const MAX_LIMIT = 25;
+const MAX_LIMIT = 15;
 
 function responsiveClass(index: number): string {
   if (index < 10) return "";
@@ -62,13 +61,18 @@ export default function Leaderboard({
   const visibleCount = data?.entries.length ?? 0;
 
   return (
-    <Card className={cn("w-full", className)} size="sm">
-      <CardHeader className="pb-2">
+    <Card
+      className={cn(
+        "self-start pb-0 bg-linear-to-b from-primary/10 to-25% dark:from-primary/15",
+        className,
+      )}
+    >
+      <CardHeader className="pb-6 border-b">
         <CardTitle>{title}</CardTitle>
         <CardDescription>{scope}</CardDescription>
       </CardHeader>
 
-      <CardContent className="pb-2">
+      <CardContent>
         {isLoading ? (
           <div className="flex flex-col gap-1">
             {Array.from({ length: 5 }).map((_, i) => (
@@ -103,12 +107,9 @@ export default function Leaderboard({
                     {entry.rank <= 3 ? (
                       rankEmojis[entry.rank - 1]
                     ) : (
-                      <Badge
-                        variant="outline"
-                        className="h-4 px-1 text-[10px] font-mono"
-                      >
+                      <span className="text-[10px] font-mono text-muted-foreground">
                         {entry.rank}
-                      </Badge>
+                      </span>
                     )}
                   </span>
 
@@ -132,9 +133,7 @@ export default function Leaderboard({
         )}
       </CardContent>
 
-      <Separator />
-
-      <CardFooter className="pt-2">
+      <CardFooter className="border-t bg-muted/50 pb-6">
         <p className="text-xs text-muted-foreground">
           Top {visibleCount}
           {locationId ? " · hover an action card to filter" : " · global"}

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -3,6 +3,16 @@
 import { useSession } from "@/hooks/use-session";
 import { useLeaderboard } from "@/hooks/use-leaderboard";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 interface LeaderboardProps {
@@ -25,109 +35,102 @@ export default function Leaderboard({
     limit,
   });
 
-  if (isLoading) {
-    return (
-      <div className={cn("rounded-lg border p-4", className)}>
-        <h3 className="font-semibold mb-3">Leaderboard</h3>
-        {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-3 py-1.5">
-            <Skeleton className="h-4 w-6" />
-            <Skeleton className="h-4 flex-1" />
-            <Skeleton className="h-4 w-10" />
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className={cn("rounded-lg border p-4", className)}>
-        <h3 className="font-semibold mb-2">Leaderboard</h3>
-        <p className="text-xs text-destructive">Failed to load.</p>
-      </div>
-    );
-  }
-
-  if (!data || data.entries.length === 0) {
-    return (
-      <div className={cn("rounded-lg border p-4", className)}>
-        <h3 className="font-semibold mb-2">Leaderboard</h3>
-        <p className="text-xs text-muted-foreground">No actions yet.</p>
-      </div>
-    );
-  }
-
-  const rankStyles: Record<number, string> = {
-    1: "text-amber-400",
-    2: "text-slate-400",
-    3: "text-orange-400",
-  };
-
-  const title = data.actionType
+  const title = data?.actionType
     ? `Leaderboard — ${data.actionType}`
     : "Leaderboard";
 
   const scope =
-    data.actionType && locationId
-      ? `Filtered by action`
-      : data.actionType
-        ? `Filtered by action`
+    data?.actionType && locationId
+      ? "Filtered by action"
+      : data?.actionType
+        ? "Filtered by action"
         : locationId
-          ? `All actions`
-          : `All actions · Global`;
+          ? "All actions"
+          : "All actions · Global";
+
+  const rankVariants: Record<number, "default" | "secondary" | "outline"> = {
+    1: "default",
+    2: "secondary",
+    3: "outline",
+  };
+
+  const rankEmojis = ["🥇", "🥈", "🥉"];
 
   return (
-    <div className={cn("rounded-lg border p-4", className)}>
-      <h3 className="font-semibold text-sm mb-1">{title}</h3>
-      <p className="text-[10px] text-muted-foreground mb-3">{scope}</p>
+    <Card className={cn("w-full", className)} size="sm">
+      <CardHeader className="pb-2">
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{scope}</CardDescription>
+      </CardHeader>
 
-      <div className="flex flex-col gap-0.5">
-        {data.entries.map((entry) => {
-          const isCurrentUser = session?.user.id === entry.userId;
-          const label = entry.displayName ?? `User #${entry.anonymousLabel}`;
+      <CardContent className="pb-2">
+        {isLoading ? (
+          <div className="flex flex-col gap-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 py-1">
+                <Skeleton className="h-5 w-8" />
+                <Skeleton className="h-4 flex-1" />
+                <Skeleton className="h-4 w-10" />
+              </div>
+            ))}
+          </div>
+        ) : error ? (
+          <p className="text-sm text-destructive">Failed to load.</p>
+        ) : !data || data.entries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No actions yet.</p>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {data.entries.map((entry) => {
+              const isCurrentUser = session?.user.id === entry.userId;
+              const label =
+                entry.displayName ?? `User #${entry.anonymousLabel}`;
 
-          return (
-            <div
-              key={entry.userId}
-              className={cn(
-                "flex items-center gap-2 px-1.5 py-1 rounded text-xs",
-                isCurrentUser && "bg-amber-500/10",
-              )}
-            >
-              <span
-                className={cn(
-                  "w-5 text-right font-mono font-bold text-[11px]",
-                  rankStyles[entry.rank] ?? "text-muted-foreground",
-                )}
-              >
-                {entry.rank <= 3
-                  ? ["🥇", "🥈", "🥉"][entry.rank - 1]
-                  : `#${entry.rank}`}
-              </span>
+              return (
+                <div
+                  key={entry.userId}
+                  className={cn(
+                    "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
+                    isCurrentUser && "bg-accent",
+                  )}
+                >
+                  <span className="w-5 text-center">
+                    {entry.rank <= 3 ? (
+                      rankEmojis[entry.rank - 1]
+                    ) : (
+                      <Badge variant="outline" className="h-4 px-1 text-[10px] font-mono">
+                        {entry.rank}
+                      </Badge>
+                    )}
+                  </span>
 
-              <span
-                className={cn(
-                  "flex-1 truncate",
-                  isCurrentUser && "font-semibold text-amber-500",
-                )}
-              >
-                {label}
-                {isCurrentUser ? " (you)" : ""}
-              </span>
+                  <span
+                    className={cn(
+                      "flex-1 truncate",
+                      isCurrentUser && "font-medium",
+                    )}
+                  >
+                    {label}
+                    {isCurrentUser ? " (you)" : ""}
+                  </span>
 
-              <span className="font-mono text-muted-foreground tabular-nums">
-                {entry.totalActions.toLocaleString()}
-              </span>
-            </div>
-          );
-        })}
-      </div>
+                  <span className="font-mono text-xs text-muted-foreground tabular-nums">
+                    {entry.totalActions.toLocaleString()}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
 
-      <p className="text-[10px] text-muted-foreground mt-3">
-        Top {data.entries.length}
-        {locationId ? " · hover an action card to filter" : " · global"}
-      </p>
-    </div>
+      <Separator />
+
+      <CardFooter className="pt-2">
+        <p className="text-xs text-muted-foreground">
+          Top {data?.entries.length ?? 0}
+          {locationId ? " · hover an action card to filter" : " · global"}
+        </p>
+      </CardFooter>
+    </Card>
   );
 }

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -20,6 +20,7 @@ interface LeaderboardProps {
   actionType: string | null;
   limit?: number;
   className?: string;
+  context?: "guild";
 }
 
 const MAX_LIMIT = 15;
@@ -36,11 +37,13 @@ export default function Leaderboard({
   actionType,
   limit = MAX_LIMIT,
   className,
+  context,
 }: LeaderboardProps) {
   const { data, isLoading, error } = useLeaderboard({
     locationId,
     actionType,
     limit,
+    scope: context,
   });
 
   const title = data?.actionType

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useSession } from "@/hooks/use-session";
+import { useLeaderboard } from "@/hooks/use-leaderboard";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface LeaderboardProps {
+  locationId: string | null;
+  actionType: string | null;
+  limit?: number;
+  className?: string;
+}
+
+export default function Leaderboard({
+  locationId,
+  actionType,
+  limit = 10,
+  className,
+}: LeaderboardProps) {
+  const { session } = useSession();
+  const { data, isLoading, error } = useLeaderboard({
+    locationId,
+    actionType,
+    limit,
+  });
+
+  if (!locationId) {
+    return (
+      <div className={cn("rounded-lg border p-4", className)}>
+        <p className="text-sm text-muted-foreground">
+          Select a location to view the leaderboard.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className={cn("rounded-lg border p-4", className)}>
+        <h3 className="font-semibold mb-3">Leaderboard</h3>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 py-1.5">
+            <Skeleton className="h-4 w-6" />
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-4 w-10" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={cn("rounded-lg border p-4", className)}>
+        <h3 className="font-semibold mb-2">Leaderboard</h3>
+        <p className="text-xs text-destructive">Failed to load.</p>
+      </div>
+    );
+  }
+
+  if (!data || data.entries.length === 0) {
+    return (
+      <div className={cn("rounded-lg border p-4", className)}>
+        <h3 className="font-semibold mb-2">Leaderboard</h3>
+        <p className="text-xs text-muted-foreground">No actions yet.</p>
+      </div>
+    );
+  }
+
+  const rankStyles: Record<number, string> = {
+    1: "text-amber-400",
+    2: "text-slate-400",
+    3: "text-orange-400",
+  };
+
+  const title = data.actionType
+    ? `Leaderboard — ${data.actionType}`
+    : "Leaderboard";
+
+  return (
+    <div className={cn("rounded-lg border p-4", className)}>
+      <h3 className="font-semibold text-sm mb-1">{title}</h3>
+      <p className="text-[10px] text-muted-foreground mb-3">
+        {data.actionType ? "Filtered by action" : "All actions"}
+      </p>
+
+      <div className="flex flex-col gap-0.5">
+        {data.entries.map((entry) => {
+          const isCurrentUser = session?.user.id === entry.userId;
+          const label = entry.displayName ?? `User #${entry.anonymousLabel}`;
+
+          return (
+            <div
+              key={entry.userId}
+              className={cn(
+                "flex items-center gap-2 px-1.5 py-1 rounded text-xs",
+                isCurrentUser && "bg-amber-500/10",
+              )}
+            >
+              <span
+                className={cn(
+                  "w-5 text-right font-mono font-bold text-[11px]",
+                  rankStyles[entry.rank] ?? "text-muted-foreground",
+                )}
+              >
+                {entry.rank <= 3
+                  ? ["🥇", "🥈", "🥉"][entry.rank - 1]
+                  : `#${entry.rank}`}
+              </span>
+
+              <span
+                className={cn(
+                  "flex-1 truncate",
+                  isCurrentUser && "font-semibold text-amber-500",
+                )}
+              >
+                {label}
+                {isCurrentUser ? " (you)" : ""}
+              </span>
+
+              <span className="font-mono text-muted-foreground tabular-nums">
+                {entry.totalActions.toLocaleString()}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="text-[10px] text-muted-foreground mt-3">
+        Top {data.entries.length} &middot; hover an action card to filter
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -25,16 +25,6 @@ export default function Leaderboard({
     limit,
   });
 
-  if (!locationId) {
-    return (
-      <div className={cn("rounded-lg border p-4", className)}>
-        <p className="text-sm text-muted-foreground">
-          Select a location to view the leaderboard.
-        </p>
-      </div>
-    );
-  }
-
   if (isLoading) {
     return (
       <div className={cn("rounded-lg border p-4", className)}>
@@ -78,12 +68,19 @@ export default function Leaderboard({
     ? `Leaderboard — ${data.actionType}`
     : "Leaderboard";
 
+  const scope =
+    data.actionType && locationId
+      ? `Filtered by action`
+      : data.actionType
+        ? `Filtered by action`
+        : locationId
+          ? `All actions`
+          : `All actions · Global`;
+
   return (
     <div className={cn("rounded-lg border p-4", className)}>
       <h3 className="font-semibold text-sm mb-1">{title}</h3>
-      <p className="text-[10px] text-muted-foreground mb-3">
-        {data.actionType ? "Filtered by action" : "All actions"}
-      </p>
+      <p className="text-[10px] text-muted-foreground mb-3">{scope}</p>
 
       <div className="flex flex-col gap-0.5">
         {data.entries.map((entry) => {
@@ -128,7 +125,8 @@ export default function Leaderboard({
       </div>
 
       <p className="text-[10px] text-muted-foreground mt-3">
-        Top {data.entries.length} &middot; hover an action card to filter
+        Top {data.entries.length}
+        {locationId ? " · hover an action card to filter" : " · global"}
       </p>
     </div>
   );

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -22,10 +22,19 @@ interface LeaderboardProps {
   className?: string;
 }
 
+const MAX_LIMIT = 25;
+
+function responsiveClass(index: number): string {
+  if (index < 10) return "";
+  if (index < 15) return "hidden sm:flex";
+  if (index < 20) return "hidden md:flex";
+  return "hidden lg:flex";
+}
+
 export default function Leaderboard({
   locationId,
   actionType,
-  limit = 10,
+  limit = MAX_LIMIT,
   className,
 }: LeaderboardProps) {
   const { session } = useSession();
@@ -48,13 +57,9 @@ export default function Leaderboard({
           ? "All actions"
           : "All actions · Global";
 
-  const rankVariants: Record<number, "default" | "secondary" | "outline"> = {
-    1: "default",
-    2: "secondary",
-    3: "outline",
-  };
-
   const rankEmojis = ["🥇", "🥈", "🥉"];
+
+  const visibleCount = data?.entries.length ?? 0;
 
   return (
     <Card className={cn("w-full", className)} size="sm">
@@ -65,9 +70,9 @@ export default function Leaderboard({
 
       <CardContent className="pb-2">
         {isLoading ? (
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-1">
             {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-3 py-1">
+              <div key={i} className="flex items-center gap-3 py-1.5">
                 <Skeleton className="h-5 w-8" />
                 <Skeleton className="h-4 flex-1" />
                 <Skeleton className="h-4 w-10" />
@@ -76,11 +81,11 @@ export default function Leaderboard({
           </div>
         ) : error ? (
           <p className="text-sm text-destructive">Failed to load.</p>
-        ) : !data || data.entries.length === 0 ? (
+        ) : !data || visibleCount === 0 ? (
           <p className="text-sm text-muted-foreground">No actions yet.</p>
         ) : (
           <div className="flex flex-col gap-1">
-            {data.entries.map((entry) => {
+            {data.entries.map((entry, i) => {
               const isCurrentUser = session?.user.id === entry.userId;
               const label =
                 entry.displayName ?? `User #${entry.anonymousLabel}`;
@@ -90,6 +95,7 @@ export default function Leaderboard({
                   key={entry.userId}
                   className={cn(
                     "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
+                    responsiveClass(i),
                     isCurrentUser && "bg-accent",
                   )}
                 >
@@ -97,7 +103,10 @@ export default function Leaderboard({
                     {entry.rank <= 3 ? (
                       rankEmojis[entry.rank - 1]
                     ) : (
-                      <Badge variant="outline" className="h-4 px-1 text-[10px] font-mono">
+                      <Badge
+                        variant="outline"
+                        className="h-4 px-1 text-[10px] font-mono"
+                      >
                         {entry.rank}
                       </Badge>
                     )}
@@ -127,7 +136,7 @@ export default function Leaderboard({
 
       <CardFooter className="pt-2">
         <p className="text-xs text-muted-foreground">
-          Top {data?.entries.length ?? 0}
+          Top {visibleCount}
           {locationId ? " · hover an action card to filter" : " · global"}
         </p>
       </CardFooter>

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useSession } from "@/hooks/use-session";
+import * as React from "react";
 import { useLeaderboard } from "@/hooks/use-leaderboard";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
 
 import {
   Card,
@@ -36,7 +37,6 @@ export default function Leaderboard({
   limit = MAX_LIMIT,
   className,
 }: LeaderboardProps) {
-  const { session } = useSession();
   const { data, isLoading, error } = useLeaderboard({
     locationId,
     actionType,
@@ -90,17 +90,18 @@ export default function Leaderboard({
         ) : (
           <div className="flex flex-col gap-1">
             {data.entries.map((entry, i) => {
-              const isCurrentUser = session?.user.id === entry.userId;
               const label =
                 entry.displayName ?? `User #${entry.anonymousLabel}`;
+              const isOutsideTopN = entry.isCurrentUser && entry.rank !== i + 1;
 
               return (
+                <React.Fragment key={`${entry.anonymousLabel}-${i}`}>
+                  {isOutsideTopN && <Separator className="my-1" />}
                 <div
-                  key={entry.userId}
                   className={cn(
                     "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
                     responsiveClass(i),
-                    isCurrentUser && "bg-amber-500/10",
+                    entry.isCurrentUser && "bg-amber-500/10",
                   )}
                 >
                   <span className="w-5 text-center">
@@ -116,17 +117,18 @@ export default function Leaderboard({
                   <span
                     className={cn(
                       "flex-1 truncate",
-                      isCurrentUser && "font-medium text-amber-500",
+                      entry.isCurrentUser && "font-medium text-amber-500",
                     )}
                   >
                     {label}
-                    {isCurrentUser ? " (you)" : ""}
+                    {entry.isCurrentUser ? " (you)" : ""}
                   </span>
 
                   <span className="font-mono text-xs text-muted-foreground tabular-nums">
                     {entry.totalActions.toLocaleString()}
                   </span>
                 </div>
+                </React.Fragment>
               );
             })}
           </div>

--- a/apps/web/components/stats/stats-card.tsx
+++ b/apps/web/components/stats/stats-card.tsx
@@ -151,10 +151,6 @@ export default function StatsCard({
                   value={performedCount}
                   className="font-normal"
                 />
-                <Badge variant="outline">
-                  {formatPercentage(performedCount, totalActionsPerformed)} of
-                  actions
-                </Badge>
               </div>
             </div>
             {!hideUserCount && (
@@ -162,14 +158,16 @@ export default function StatsCard({
                 <p className="shrink">
                   <b>Users:</b>
                 </p>
-                <div className="flex justify-between grow">
-                  <NativeCounterUp value={userCount} className="font-normal" />
-                  <Badge variant="outline">
-                    {formatPercentage(userCount, totalUniqueUsers)} of users
-                  </Badge>
+                <div className="flex grow gap-1">
+                  <NativeCounterUp value={userCount} className="font-normal" />{" "}
+                  ({formatPercentage(userCount, totalUniqueUsers)})
                 </div>
               </div>
             )}
+            <p>
+              {formatPercentage(performedCount, totalActionsPerformed)} of
+              actions
+            </p>
           </div>
         </CardFooter>
       </Card>

--- a/apps/web/components/stats/stats-card.tsx
+++ b/apps/web/components/stats/stats-card.tsx
@@ -25,6 +25,8 @@ interface StatsCardProps {
   userImages?: string[];
   guildId?: string | null;
   hideUserCount?: boolean;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
 }
 
 export default function StatsCard({
@@ -37,6 +39,8 @@ export default function StatsCard({
   userImages,
   guildId,
   hideUserCount,
+  onMouseEnter,
+  onMouseLeave,
 }: StatsCardProps) {
   const displayName = actionName
     ? actionName[0].toUpperCase() + actionName.slice(1)
@@ -59,7 +63,11 @@ export default function StatsCard({
 
   return (
     <>
-      <Card className="py-0 dark:bg-linear-to-t from-primary/20 to-15%">
+      <Card
+        className="py-0 dark:bg-linear-to-t from-primary/20 to-15%"
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
         {displayImages.length > 0 ? (
           <Carousel
             setApi={setCarouselApi}

--- a/apps/web/hooks/use-leaderboard-consent.ts
+++ b/apps/web/hooks/use-leaderboard-consent.ts
@@ -1,0 +1,79 @@
+import * as React from "react";
+
+export function useLeaderboardConsent() {
+  const [enabled, setEnabled] = React.useState<boolean | null>(null);
+  const [displayName, setDisplayName] = React.useState<string | null>(null);
+  const [hashLabel, setHashLabel] = React.useState<string | null>(null);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<Error | null>(null);
+
+  const fetchStatus = React.useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const resp = await fetch("/api/leaderboard-consent");
+      if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(`fetchStatus failed (${resp.status}): ${text}`);
+      }
+      const json = (await resp.json()) as {
+        enabled: boolean;
+        displayName: string | null;
+        hashLabel: string;
+      };
+      setEnabled(json.enabled);
+      setDisplayName(json.displayName);
+      setHashLabel(json.hashLabel);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const update = React.useCallback(async (name: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const resp = await fetch("/api/leaderboard-consent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: name }),
+      });
+      if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(`update failed (${resp.status}): ${text}`);
+      }
+      setEnabled(true);
+      setDisplayName(name);
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const disable = React.useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const resp = await fetch("/api/leaderboard-consent", { method: "DELETE" });
+      if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(`disable failed (${resp.status}): ${text}`);
+      }
+      setEnabled(false);
+      setDisplayName(null);
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { enabled, displayName, hashLabel, isLoading, error, fetchStatus, update, disable } as const;
+}

--- a/apps/web/hooks/use-leaderboard.ts
+++ b/apps/web/hooks/use-leaderboard.ts
@@ -1,0 +1,52 @@
+import useSWR from "swr";
+import type { LeaderboardEntry } from "@/types/leaderboard";
+
+interface LeaderboardData {
+  locationId: string;
+  actionType: string | null;
+  entries: LeaderboardEntry[];
+}
+
+interface UseLeaderboardOptions {
+  locationId: string | null;
+  actionType?: string | null;
+  limit?: number;
+}
+
+export function useLeaderboard({
+  locationId,
+  actionType = null,
+  limit = 10,
+}: UseLeaderboardOptions) {
+  const params = new URLSearchParams();
+  if (locationId) {
+    params.set("locationId", locationId);
+    params.set("limit", String(limit));
+    if (actionType) {
+      params.set("actionType", actionType);
+    }
+  }
+
+  const key = locationId ? `/api/leaderboard?${params.toString()}` : null;
+
+  const { data, error, isLoading, mutate } = useSWR<LeaderboardData>(
+    key,
+    async (url: string) => {
+      const res = await fetch(url, { cache: "no-store" });
+      if (!res.ok) {
+        throw new Error(`Failed to fetch leaderboard (${res.status})`);
+      }
+      return res.json();
+    },
+    {
+      dedupingInterval: 2000,
+    },
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: key ? isLoading : false,
+    error: error ?? null,
+    refresh: () => mutate(),
+  };
+}

--- a/apps/web/hooks/use-leaderboard.ts
+++ b/apps/web/hooks/use-leaderboard.ts
@@ -11,12 +11,14 @@ interface UseLeaderboardOptions {
   locationId?: string | null;
   actionType?: string | null;
   limit?: number;
+  scope?: "guild";
 }
 
 export function useLeaderboard({
   locationId,
   actionType = null,
   limit = 10,
+  scope,
 }: UseLeaderboardOptions) {
   const params = new URLSearchParams();
   params.set("limit", String(limit));
@@ -25,6 +27,9 @@ export function useLeaderboard({
   }
   if (actionType) {
     params.set("actionType", actionType);
+  }
+  if (scope) {
+    params.set("scope", scope);
   }
 
   const key = `/api/leaderboard?${params.toString()}`;

--- a/apps/web/hooks/use-leaderboard.ts
+++ b/apps/web/hooks/use-leaderboard.ts
@@ -2,13 +2,13 @@ import useSWR from "swr";
 import type { LeaderboardEntry } from "@/types/leaderboard";
 
 interface LeaderboardData {
-  locationId: string;
+  locationId: string | null;
   actionType: string | null;
   entries: LeaderboardEntry[];
 }
 
 interface UseLeaderboardOptions {
-  locationId: string | null;
+  locationId?: string | null;
   actionType?: string | null;
   limit?: number;
 }
@@ -19,15 +19,15 @@ export function useLeaderboard({
   limit = 10,
 }: UseLeaderboardOptions) {
   const params = new URLSearchParams();
+  params.set("limit", String(limit));
   if (locationId) {
     params.set("locationId", locationId);
-    params.set("limit", String(limit));
-    if (actionType) {
-      params.set("actionType", actionType);
-    }
+  }
+  if (actionType) {
+    params.set("actionType", actionType);
   }
 
-  const key = locationId ? `/api/leaderboard?${params.toString()}` : null;
+  const key = `/api/leaderboard?${params.toString()}`;
 
   const { data, error, isLoading, mutate } = useSWR<LeaderboardData>(
     key,
@@ -45,7 +45,7 @@ export function useLeaderboard({
 
   return {
     data: data ?? null,
-    isLoading: key ? isLoading : false,
+    isLoading,
     error: error ?? null,
     refresh: () => mutate(),
   };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "8.6.3",
+  "version": "8.7.0",
   "private": true,
   "engines": {
     "node": ">=24",

--- a/apps/web/tests/components/leaderboard.test.tsx
+++ b/apps/web/tests/components/leaderboard.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import React from "react";
+
+// Mock useSession
+vi.mock("../../hooks/use-session", () => ({
+  useSession: () => ({ session: null }),
+}));
+
+global.fetch = vi.fn();
+
+import Leaderboard from "../../components/leaderboard";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    SWRConfig,
+    { value: { dedupingInterval: 0, provider: () => new Map() } },
+    children,
+  );
+}
+
+describe("Leaderboard component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows placeholder when no locationId", () => {
+    render(
+      React.createElement(Wrapper, null,
+        React.createElement(Leaderboard, { locationId: null, actionType: null }),
+      ),
+    );
+
+    expect(screen.getByText(/select a location/i)).toBeDefined();
+  });
+
+  it("shows empty state when no entries", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ locationId: "g1", actionType: null, entries: [] }),
+    });
+
+    render(
+      React.createElement(Wrapper, null,
+        React.createElement(Leaderboard, { locationId: "g1", actionType: null }),
+      ),
+    );
+
+    expect(await screen.findByText(/no actions yet/i)).toBeDefined();
+  });
+
+  it("renders ranked entries with display names", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        locationId: "g1",
+        actionType: null,
+        entries: [
+          { rank: 1, userId: "u1", displayName: "Alice", anonymousLabel: "abcd", totalActions: 100 },
+          { rank: 2, userId: "u2", displayName: null, anonymousLabel: "ef01", totalActions: 50 },
+        ],
+      }),
+    });
+
+    render(
+      React.createElement(Wrapper, null,
+        React.createElement(Leaderboard, { locationId: "g1", actionType: null }),
+      ),
+    );
+
+    expect(await screen.findByText("Alice")).toBeDefined();
+    expect(await screen.findByText("User #ef01")).toBeDefined();
+    expect(await screen.findByText("100")).toBeDefined();
+    expect(await screen.findByText("50")).toBeDefined();
+  });
+
+  it("shows error state on fetch failure", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    render(
+      React.createElement(Wrapper, null,
+        React.createElement(Leaderboard, { locationId: "g1", actionType: null }),
+      ),
+    );
+
+    expect(await screen.findByText(/failed to load/i)).toBeDefined();
+  });
+});

--- a/apps/web/tests/components/leaderboard.test.tsx
+++ b/apps/web/tests/components/leaderboard.test.tsx
@@ -25,14 +25,27 @@ describe("Leaderboard component", () => {
     vi.clearAllMocks();
   });
 
-  it("shows placeholder when no locationId", () => {
+  it("shows global leaderboard when no locationId", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        locationId: null,
+        actionType: null,
+        entries: [
+          { rank: 1, userId: "u1", displayName: null, anonymousLabel: "abcd", totalActions: 200 },
+        ],
+      }),
+    });
+
     render(
       React.createElement(Wrapper, null,
         React.createElement(Leaderboard, { locationId: null, actionType: null }),
       ),
     );
 
-    expect(screen.getByText(/select a location/i)).toBeDefined();
+    expect(await screen.findByText("User #abcd")).toBeDefined();
+    const globalHints = await screen.findAllByText(/global/i);
+    expect(globalHints.length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows empty state when no entries", async () => {

--- a/apps/web/tests/hooks/use-leaderboard-consent.test.ts
+++ b/apps/web/tests/hooks/use-leaderboard-consent.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+/// <reference lib="dom" />
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+
+import { useLeaderboardConsent } from "@/hooks/use-leaderboard-consent";
+
+function renderHook<T>(hookFn: () => T) {
+  const result: { current: T } = { current: null as unknown as T };
+
+  function HookHarness() {
+    result.current = hookFn();
+    return null;
+  }
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(createElement(HookHarness));
+  });
+
+  return {
+    result,
+    unmount() {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("useLeaderboardConsent", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("exposes initial state: enabled null, displayName null, hashLabel null, isLoading false", () => {
+    const { result, unmount } = renderHook(() => useLeaderboardConsent());
+    expect(result.current.enabled).toBeNull();
+    expect(result.current.displayName).toBeNull();
+    expect(result.current.hashLabel).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it("fetchStatus: sets enabled true with displayName and hashLabel", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ enabled: true, displayName: "MyName", hashLabel: "User #abc123" }),
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useLeaderboardConsent());
+
+    await act(async () => {
+      await result.current.fetchStatus();
+    });
+
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.displayName).toBe("MyName");
+    expect(result.current.hashLabel).toBe("User #abc123");
+    unmount();
+  });
+
+  it("fetchStatus: sets enabled false when server returns no consent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ enabled: false, displayName: null, hashLabel: "User #def456" }),
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useLeaderboardConsent());
+
+    await act(async () => {
+      await result.current.fetchStatus();
+    });
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.displayName).toBeNull();
+    expect(result.current.hashLabel).toBe("User #def456");
+    unmount();
+  });
+
+  it("update: sends POST with displayName and sets enabled", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
+
+    const { result, unmount } = renderHook(() => useLeaderboardConsent());
+
+    let returnValue = false;
+    await act(async () => {
+      returnValue = await result.current.update("CoolName");
+    });
+
+    expect(returnValue).toBe(true);
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.displayName).toBe("CoolName");
+    expect(fetch).toHaveBeenCalledWith("/api/leaderboard-consent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ displayName: "CoolName" }),
+    });
+    unmount();
+  });
+
+  it("disable: sends DELETE and sets enabled false", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
+
+    const { result, unmount } = renderHook(() => useLeaderboardConsent());
+
+    let returnValue = false;
+    await act(async () => {
+      returnValue = await result.current.disable();
+    });
+
+    expect(returnValue).toBe(true);
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.displayName).toBeNull();
+    expect(fetch).toHaveBeenCalledWith("/api/leaderboard-consent", { method: "DELETE" });
+    unmount();
+  });
+
+  it("update: sets error and returns false on failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500, text: async () => "Server Error" }),
+    );
+
+    const { result, unmount } = renderHook(() => useLeaderboardConsent());
+
+    let returnValue = true;
+    await act(async () => {
+      returnValue = await result.current.update("BadName");
+    });
+
+    expect(returnValue).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+    unmount();
+  });
+
+  it("disable: sets error and returns false on failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500, text: async () => "Server Error" }),
+    );
+
+    const { result, unmount } = renderHook(() => useLeaderboardConsent());
+
+    let returnValue = true;
+    await act(async () => {
+      returnValue = await result.current.disable();
+    });
+
+    expect(returnValue).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+    unmount();
+  });
+});

--- a/apps/web/tests/hooks/use-leaderboard.test.ts
+++ b/apps/web/tests/hooks/use-leaderboard.test.ts
@@ -21,14 +21,27 @@ describe("useLeaderboard", () => {
     vi.clearAllMocks();
   });
 
-  it("returns null key when locationId is null", () => {
+  it("fetches global leaderboard when locationId is null", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        locationId: null,
+        actionType: null,
+        entries: [{ rank: 1, userId: "u1", displayName: null, anonymousLabel: "abcd", totalActions: 100 }],
+      }),
+    });
+
     const { result } = renderHook(
       () => useLeaderboard({ locationId: null }),
       { wrapper },
     );
 
-    expect(result.current.data).toBeNull();
-    expect(result.current.isLoading).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data?.entries).toHaveLength(1);
+    expect(result.current.data?.locationId).toBeNull();
   });
 
   it("fetches and returns leaderboard data", async () => {

--- a/apps/web/tests/hooks/use-leaderboard.test.ts
+++ b/apps/web/tests/hooks/use-leaderboard.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import React from "react";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import { useLeaderboard } from "../../hooks/use-leaderboard";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    SWRConfig,
+    { value: { dedupingInterval: 0, provider: () => new Map() } },
+    children,
+  );
+}
+
+describe("useLeaderboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null key when locationId is null", () => {
+    const { result } = renderHook(
+      () => useLeaderboard({ locationId: null }),
+      { wrapper },
+    );
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("fetches and returns leaderboard data", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        locationId: "g1",
+        actionType: null,
+        entries: [{ rank: 1, userId: "u1", displayName: null, anonymousLabel: "abcd", totalActions: 100 }],
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useLeaderboard({ locationId: "g1" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data?.entries).toHaveLength(1);
+  });
+
+  it("handles fetch errors", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const { result } = renderHook(
+      () => useLeaderboard({ locationId: "g1" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/types/leaderboard.ts
+++ b/apps/web/types/leaderboard.ts
@@ -1,7 +1,7 @@
 export interface LeaderboardEntry {
   rank: number;
-  userId: string;
   displayName: string | null;
   anonymousLabel: string;
   totalActions: number;
+  isCurrentUser: boolean;
 }

--- a/apps/web/types/leaderboard.ts
+++ b/apps/web/types/leaderboard.ts
@@ -1,0 +1,7 @@
+export interface LeaderboardEntry {
+  rank: number;
+  userId: string;
+  displayName: string | null;
+  anonymousLabel: string;
+  totalActions: number;
+}

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 - Hovering an action card on the global stats page filters the leaderboard to that action.
 - Added a leaderboard display name setting — choose to show your name instead of appearing anonymous. Defaults to your Discord username.
 - Current user is highlighted with an amber tint on the leaderboard.
-- Leaderboard shows up to 25 entries on larger screens.
+- Leaderboard shows up to 15 entries.
 - Stats cards have a cleaner footer layout.
 
 ### Under the Hood

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,25 @@
+## v8.7.0 - May 28, 2026
+
+### What You'll Notice
+
+- Added leaderboards to the web dashboard, showing top users by action count on global, guild, and DM stats pages.
+- Added a `/leaderboard` Discord slash command.
+- Hovering an action card on the global stats page filters the leaderboard to that action.
+- Added a leaderboard display name setting — choose to show your name instead of appearing anonymous. Defaults to your Discord username.
+- Current user is highlighted with an amber tint on the leaderboard.
+- Leaderboard shows up to 25 entries on larger screens.
+- Stats cards have a cleaner footer layout.
+
+### Under the Hood
+
+- Added `leaderboardConsent` table for storing display name consent against hashed user IDs, keeping raw Discord IDs and display names in separate tables.
+- Leaderboard consent CRUD follows the existing opt-out pattern (Express route + Next.js proxy + React hook).
+- Extracted shared `hashUserId` utility for consistent hashing.
+- Global stats page uses a responsive grid layout so the leaderboard reflows below stats on smaller screens.
+- Migrated leaderboard to shadcn Card components.
+- Anonymous user labels now show 6 hex characters instead of 4.
+- Comprehensive tests for leaderboard backend, frontend, consent routes, and hooks.
+
 ## v8.6.3 - May 27, 2026
 
 ### Fixes

--- a/drizzle/20260528222821_equal_human_torch/migration.sql
+++ b/drizzle/20260528222821_equal_human_torch/migration.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `leaderboardConsent` (
+	`hashed_user_id` text PRIMARY KEY,
+	`display_name` text NOT NULL,
+	`createdAt` text NOT NULL,
+	`updatedAt` text NOT NULL
+);

--- a/drizzle/20260528222821_equal_human_torch/snapshot.json
+++ b/drizzle/20260528222821_equal_human_torch/snapshot.json
@@ -1,0 +1,411 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "873bb927-e08e-4363-a10b-fb7d9752b35e",
+  "prevIds": [
+    "2a9532c8-81c6-4b94-b792-86ca3ca44309"
+  ],
+  "ddl": [
+    {
+      "name": "actionData",
+      "entityType": "tables"
+    },
+    {
+      "name": "botData",
+      "entityType": "tables"
+    },
+    {
+      "name": "leaderboardConsent",
+      "entityType": "tables"
+    },
+    {
+      "name": "optOut",
+      "entityType": "tables"
+    },
+    {
+      "name": "SequelizeMeta",
+      "entityType": "tables"
+    },
+    {
+      "name": "userSessions",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "actionData"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "actionData"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "actionData"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "action_type",
+      "entityType": "columns",
+      "table": "actionData"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "has_performed",
+      "entityType": "columns",
+      "table": "actionData"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "has_received",
+      "entityType": "columns",
+      "table": "actionData"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "images",
+      "entityType": "columns",
+      "table": "actionData"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "actionData"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "actionData"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "botData"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "guild_id",
+      "entityType": "columns",
+      "table": "botData"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "log_channel",
+      "entityType": "columns",
+      "table": "botData"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "nickname",
+      "entityType": "columns",
+      "table": "botData"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "botData"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "botData"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sleep_image",
+      "entityType": "columns",
+      "table": "botData"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "default_images",
+      "entityType": "columns",
+      "table": "botData"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "restricted",
+      "entityType": "columns",
+      "table": "botData"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "hashed_user_id",
+      "entityType": "columns",
+      "table": "leaderboardConsent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "table": "leaderboardConsent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "leaderboardConsent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "leaderboardConsent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "optOut"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "optOut"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "optOut"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "SequelizeMeta"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "userSessions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'[]'",
+      "generated": null,
+      "name": "guilds",
+      "entityType": "columns",
+      "table": "userSessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "table": "userSessions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "table": "userSessions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "actionData_pk",
+      "table": "actionData",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "botData_pk",
+      "table": "botData",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "hashed_user_id"
+      ],
+      "nameExplicit": false,
+      "name": "leaderboardConsent_pk",
+      "table": "leaderboardConsent",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "optOut_pk",
+      "table": "optOut",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "name"
+      ],
+      "nameExplicit": false,
+      "name": "SequelizeMeta_pk",
+      "table": "SequelizeMeta",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "userSessions_pk",
+      "table": "userSessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        },
+        {
+          "value": "location_id",
+          "isExpression": false
+        },
+        {
+          "value": "action_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "action_data_unique_constraint",
+      "entityType": "indexes",
+      "table": "actionData"
+    }
+  ],
+  "renames": []
+}

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -52,3 +52,10 @@ export const userSessions = sqliteTable("userSessions", {
   createdAt: numeric().notNull(),
   updatedAt: numeric().notNull(),
 });
+
+export const leaderboardConsent = sqliteTable("leaderboardConsent", {
+  hashedUserId: text("hashed_user_id").primaryKey(),
+  displayName: text("display_name").notNull(),
+  createdAt: numeric().notNull(),
+  updatedAt: numeric().notNull(),
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "petbot",
-  "version": "8.6.1",
+  "version": "8.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "petbot",
-      "version": "8.6.1",
+      "version": "8.7.0",
       "license": "ISC",
       "workspaces": [
         "apps/web"
@@ -47,7 +47,7 @@
       }
     },
     "apps/web": {
-      "version": "8.6.1",
+      "version": "8.7.0",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petbot",
-  "version": "8.6.3",
+  "version": "8.7.0",
   "description": "",
   "type": "module",
   "packageManager": "npm@11.16.0",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,6 +20,7 @@ import serverSetup from "./slash/serverSetup.js";
 import setCmd from "./slash/set.js";
 import squish from "./slash/squish.js";
 import stats from "./slash/stats.js";
+import leaderboard from "./slash/leaderboard.js";
 
 // Context commands
 import biteContext from "./context/biteContext.js";
@@ -42,6 +43,7 @@ export const slashCommands = [
   setCmd,
   squish,
   stats,
+  leaderboard,
 ];
 
 export const contextCommands = [

--- a/src/commands/slash/leaderboard.ts
+++ b/src/commands/slash/leaderboard.ts
@@ -1,0 +1,87 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  MessageFlags,
+  InteractionContextType,
+  ApplicationIntegrationType,
+  EmbedBuilder,
+} from "discord.js";
+import { getLeaderboard } from "../../utilities/leaderboard.js";
+
+export const command = {
+  data: new SlashCommandBuilder()
+    .setName("leaderboard")
+    .setDescription("View the top 10 action rankings")
+    .addStringOption((option) =>
+      option
+        .setName("action")
+        .setDescription("Filter by action type (omit for all actions)")
+        .setRequired(false)
+        .addChoices(
+          { name: "Pet", value: "pet" },
+          { name: "Bite", value: "bite" },
+          { name: "Hug", value: "hug" },
+          { name: "Bonk", value: "bonk" },
+          { name: "Squish", value: "squish" },
+          { name: "Explode", value: "explode" },
+        ),
+    )
+    .setIntegrationTypes([
+      ApplicationIntegrationType.GuildInstall,
+      ApplicationIntegrationType.UserInstall,
+    ])
+    .setContexts([
+      InteractionContextType.BotDM,
+      InteractionContextType.Guild,
+      InteractionContextType.PrivateChannel,
+    ]),
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply({
+      flags: MessageFlags.Ephemeral,
+    });
+
+    const actionType = interaction.options.getString("action") ?? undefined;
+    const locationId = interaction.guildId ?? interaction.channelId;
+    if (!locationId) {
+      await interaction.editReply("Could not determine location.");
+      return;
+    }
+
+    const result = await getLeaderboard({
+      locationId,
+      actionType,
+      limit: 10,
+      discordClient: interaction.client,
+    });
+
+    if (result.entries.length === 0) {
+      await interaction.editReply("No actions recorded here yet.");
+      return;
+    }
+
+    const rankEmojis = ["🥇", "🥈", "🥉"];
+    const title = actionType
+      ? `Leaderboard — ${actionType}`
+      : "Leaderboard — All Actions";
+
+    const description = result.entries
+      .map((entry) => {
+        const emoji = rankEmojis[entry.rank - 1] ?? `#${entry.rank}`;
+        const label = entry.displayName ?? `User #${entry.anonymousLabel}`;
+        const you = entry.userId === interaction.user.id ? " **(you)**" : "";
+        return `${emoji} ${label} — ${entry.totalActions}${you}`;
+      })
+      .join("\n");
+
+    const embed = new EmbedBuilder()
+      .setTitle(title)
+      .setDescription(description)
+      .setColor(0xf59e0b)
+      .setFooter({ text: `Location: ${locationId}` });
+
+    await interaction.editReply({ embeds: [embed] });
+  },
+};
+
+export default command;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -57,3 +57,10 @@ export const optOut = sqliteTable("optOut", {
   createdAt: text().notNull(),
   updatedAt: text().notNull(),
 });
+
+export const leaderboardConsent = sqliteTable("leaderboardConsent", {
+  hashedUserId: text("hashed_user_id").primaryKey(),
+  displayName: text("display_name").notNull(),
+  createdAt: text().notNull(),
+  updatedAt: text().notNull(),
+});

--- a/src/http/expressServer.ts
+++ b/src/http/expressServer.ts
@@ -14,6 +14,7 @@ import readyHandler from "./routes/ready.js";
 
 // Migrated Express route handlers
 import statsHandler from "./routes/stats.js";
+import leaderboardHandler from "./routes/leaderboard.js";
 import guildsHandler from "./routes/guilds.js";
 import userSessionsRouter from "./routes/userSessions.js";
 import userDataHandler from "./routes/userData.js";
@@ -82,6 +83,7 @@ export function createApp(client?: Client<boolean>): express.Express {
     },
     statsHandler,
   );
+  app.get("/api/leaderboard", leaderboardHandler);
   app.get("/api/guilds", guildsHandler);
   app.get("/api/guilds/user/:userId", guildsHandler);
   app.use("/api/userSessions", userSessionsRouter);

--- a/src/http/expressServer.ts
+++ b/src/http/expressServer.ts
@@ -83,7 +83,6 @@ export function createApp(client?: Client<boolean>): express.Express {
     },
     statsHandler,
   );
-  app.get("/api/leaderboard", leaderboardHandler);
   app.get("/api/guilds", guildsHandler);
   app.get("/api/guilds/user/:userId", guildsHandler);
   app.use("/api/userSessions", userSessionsRouter);
@@ -100,6 +99,7 @@ export function createApp(client?: Client<boolean>): express.Express {
       "/api/guildChannels/:guildId/user/:userId",
       guildChannelsHandler(client),
     );
+    app.get("/api/leaderboard", leaderboardHandler(client));
   }
 
   // --- 404 fallback for unmatched /api/* ---

--- a/src/http/expressServer.ts
+++ b/src/http/expressServer.ts
@@ -19,6 +19,7 @@ import guildsHandler from "./routes/guilds.js";
 import userSessionsRouter from "./routes/userSessions.js";
 import userDataHandler from "./routes/userData.js";
 import optOutRouter from "./routes/optOut.js";
+import leaderboardConsentRouter from "./routes/leaderboardConsent.js";
 import setImagesHandler from "./routes/setImages.js";
 import serverSettingsRouter from "./routes/serverSettings.js";
 import guildChannelsHandler from "./routes/guildChannels.js";
@@ -90,6 +91,7 @@ export function createApp(client?: Client<boolean>): express.Express {
 
   // --- Phase 2b: write/update endpoints ---
   app.use("/api/optOut", optOutRouter);
+  app.use("/api/leaderboardConsent", leaderboardConsentRouter);
   app.post("/api/setImages", setImagesHandler);
 
   // Routes that need the Discord client

--- a/src/http/routes/leaderboard.ts
+++ b/src/http/routes/leaderboard.ts
@@ -7,11 +7,6 @@ export default function leaderboardHandler(client: Client) {
   return async function (req: Request, res: Response): Promise<void> {
     try {
       const locationId = req.query.locationId as string | undefined;
-      if (!locationId) {
-        res.status(400).json({ error: "missing_locationId" });
-        return;
-      }
-
       const actionType = (req.query.actionType as string | undefined) ?? undefined;
       const limit = Math.min(
         parseInt(req.query.limit as string, 10) || 10,

--- a/src/http/routes/leaderboard.ts
+++ b/src/http/routes/leaderboard.ts
@@ -8,6 +8,7 @@ export default function leaderboardHandler(client: Client) {
     try {
       const locationId = req.query.locationId as string | undefined;
       const actionType = (req.query.actionType as string | undefined) ?? undefined;
+      const currentUserId = req.query.currentUserId as string | undefined;
       const limit = Math.min(
         parseInt(req.query.limit as string, 10) || 10,
         25,
@@ -25,6 +26,7 @@ export default function leaderboardHandler(client: Client) {
         locationId,
         actionType,
         limit,
+        currentUserId,
         discordClient: client,
       });
 

--- a/src/http/routes/leaderboard.ts
+++ b/src/http/routes/leaderboard.ts
@@ -1,46 +1,42 @@
 import type { Request, Response } from "express";
+import type { Client } from "discord.js";
 import { getLeaderboard } from "../../utilities/leaderboard.js";
 import logger from "../../logger.js";
 
-export default async function leaderboardHandler(
-  req: Request,
-  res: Response,
-): Promise<void> {
-  try {
-    const locationId = req.query.locationId as string | undefined;
-    if (!locationId) {
-      res.status(400).json({ error: "missing_locationId" });
-      return;
+export default function leaderboardHandler(client: Client) {
+  return async function (req: Request, res: Response): Promise<void> {
+    try {
+      const locationId = req.query.locationId as string | undefined;
+      if (!locationId) {
+        res.status(400).json({ error: "missing_locationId" });
+        return;
+      }
+
+      const actionType = (req.query.actionType as string | undefined) ?? undefined;
+      const limit = Math.min(
+        parseInt(req.query.limit as string, 10) || 10,
+        25,
+      );
+
+      if (
+        actionType &&
+        !["pet", "bite", "hug", "bonk", "squish", "explode"].includes(actionType)
+      ) {
+        res.status(400).json({ error: "invalid_actionType" });
+        return;
+      }
+
+      const result = await getLeaderboard({
+        locationId,
+        actionType,
+        limit,
+        discordClient: client,
+      });
+
+      res.json(result);
+    } catch (err) {
+      logger.error({ err }, "/api/leaderboard error");
+      res.status(500).json({ error: "server_error" });
     }
-
-    const actionType = (req.query.actionType as string | undefined) ?? undefined;
-    const limit = Math.min(
-      parseInt(req.query.limit as string, 10) || 10,
-      25,
-    );
-
-    // Validate actionType if provided
-    if (actionType && !["pet", "bite", "hug", "bonk", "squish", "explode"].includes(actionType)) {
-      res.status(400).json({ error: "invalid_actionType" });
-      return;
-    }
-
-    const discordClient = req.app.locals.client;
-    if (!discordClient) {
-      res.status(503).json({ error: "bot_not_ready" });
-      return;
-    }
-
-    const result = await getLeaderboard({
-      locationId,
-      actionType,
-      limit,
-      discordClient,
-    });
-
-    res.json(result);
-  } catch (err) {
-    logger.error({ err }, "/api/leaderboard error");
-    res.status(500).json({ error: "server_error" });
-  }
+  };
 }

--- a/src/http/routes/leaderboard.ts
+++ b/src/http/routes/leaderboard.ts
@@ -1,0 +1,46 @@
+import type { Request, Response } from "express";
+import { getLeaderboard } from "../../utilities/leaderboard.js";
+import logger from "../../logger.js";
+
+export default async function leaderboardHandler(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const locationId = req.query.locationId as string | undefined;
+    if (!locationId) {
+      res.status(400).json({ error: "missing_locationId" });
+      return;
+    }
+
+    const actionType = (req.query.actionType as string | undefined) ?? undefined;
+    const limit = Math.min(
+      parseInt(req.query.limit as string, 10) || 10,
+      25,
+    );
+
+    // Validate actionType if provided
+    if (actionType && !["pet", "bite", "hug", "bonk", "squish", "explode"].includes(actionType)) {
+      res.status(400).json({ error: "invalid_actionType" });
+      return;
+    }
+
+    const discordClient = req.app.locals.client;
+    if (!discordClient) {
+      res.status(503).json({ error: "bot_not_ready" });
+      return;
+    }
+
+    const result = await getLeaderboard({
+      locationId,
+      actionType,
+      limit,
+      discordClient,
+    });
+
+    res.json(result);
+  } catch (err) {
+    logger.error({ err }, "/api/leaderboard error");
+    res.status(500).json({ error: "server_error" });
+  }
+}

--- a/src/http/routes/leaderboardConsent.ts
+++ b/src/http/routes/leaderboardConsent.ts
@@ -38,6 +38,11 @@ router.post("/:hashedUserId", async (req: Request, res: Response) => {
     return;
   }
 
+  if (displayName.trim().length > 100) {
+    res.status(400).json({ error: "displayName_too_long" });
+    return;
+  }
+
   const now = new Date().toISOString();
 
   try {

--- a/src/http/routes/leaderboardConsent.ts
+++ b/src/http/routes/leaderboardConsent.ts
@@ -1,0 +1,72 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { leaderboardConsent } from "../../db/schema.js";
+import { drizzleDb } from "../../db/connector.js";
+import { eq } from "drizzle-orm";
+import logger from "../../logger.js";
+
+const router = Router();
+
+router.get("/:hashedUserId", async (req: Request, res: Response) => {
+  const hashedUserId = req.params.hashedUserId as string;
+
+  try {
+    const rows = await drizzleDb
+      .select()
+      .from(leaderboardConsent)
+      .where(eq(leaderboardConsent.hashedUserId, hashedUserId))
+      .limit(1);
+
+    if (rows.length === 0) {
+      res.json({ enabled: false, displayName: null });
+      return;
+    }
+
+    res.json({ enabled: true, displayName: rows[0].displayName });
+  } catch (err) {
+    logger.error({ err }, "leaderboardConsent GET error");
+    res.status(500).json({ error: "server_error" });
+  }
+});
+
+router.post("/:hashedUserId", async (req: Request, res: Response) => {
+  const hashedUserId = req.params.hashedUserId as string;
+  const { displayName } = req.body as { displayName?: string };
+
+  if (!displayName || typeof displayName !== "string" || displayName.trim().length === 0) {
+    res.status(400).json({ error: "displayName_required" });
+    return;
+  }
+
+  const now = new Date().toISOString();
+
+  try {
+    await drizzleDb
+      .insert(leaderboardConsent)
+      .values({ hashedUserId, displayName: displayName.trim(), createdAt: now, updatedAt: now })
+      .onConflictDoUpdate({
+        target: leaderboardConsent.hashedUserId,
+        set: { displayName: displayName.trim(), updatedAt: now },
+      });
+    res.json({ ok: true });
+  } catch (err) {
+    logger.error({ err }, "leaderboardConsent POST error");
+    res.status(500).json({ error: "server_error" });
+  }
+});
+
+router.delete("/:hashedUserId", async (req: Request, res: Response) => {
+  const hashedUserId = req.params.hashedUserId as string;
+
+  try {
+    await drizzleDb
+      .delete(leaderboardConsent)
+      .where(eq(leaderboardConsent.hashedUserId, hashedUserId));
+    res.json({ ok: true });
+  } catch (err) {
+    logger.error({ err }, "leaderboardConsent DELETE error");
+    res.status(500).json({ error: "server_error" });
+  }
+});
+
+export default router;

--- a/src/utilities/crypto.ts
+++ b/src/utilities/crypto.ts
@@ -23,3 +23,11 @@ export function secureEqual(a?: string, b?: string): boolean {
     return false;
   }
 }
+
+/**
+ * Hash a user ID for anonymous display and consent lookup.
+ * Returns the first `len` hex characters of the SHA-256 digest.
+ */
+export function hashUserId(userId: string, len = 6): string {
+  return crypto.createHash("sha256").update(userId).digest("hex").slice(0, len);
+}

--- a/src/utilities/crypto.ts
+++ b/src/utilities/crypto.ts
@@ -28,6 +28,6 @@ export function secureEqual(a?: string, b?: string): boolean {
  * Hash a user ID for anonymous display and consent lookup.
  * Returns the first `len` hex characters of the SHA-256 digest.
  */
-export function hashUserId(userId: string, len = 6): string {
+export function hashUserId(userId: string, len = 16): string {
   return crypto.createHash("sha256").update(userId).digest("hex").slice(0, len);
 }

--- a/src/utilities/leaderboard.ts
+++ b/src/utilities/leaderboard.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import { Client, Guild } from "discord.js";
+import { drizzleDb } from "../db/connector.js";
+import { actionData } from "../db/schema.js";
+import { eq, and, desc, sum } from "drizzle-orm";
+
+export interface LeaderboardEntry {
+  rank: number;
+  userId: string;
+  displayName: string | null;
+  anonymousLabel: string;
+  totalActions: number;
+}
+
+export interface LeaderboardResult {
+  locationId: string;
+  actionType: string | null;
+  entries: LeaderboardEntry[];
+}
+
+function hashUserId(userId: string): string {
+  return createHash("sha256").update(userId).digest("hex").slice(0, 4);
+}
+
+export async function getLeaderboard(opts: {
+  locationId: string;
+  actionType?: string;
+  limit?: number;
+  discordClient: Client;
+}): Promise<LeaderboardResult> {
+  const { locationId, actionType, limit = 10, discordClient } = opts;
+
+  const whereClauses = [eq(actionData.locationId, locationId)];
+  if (actionType) {
+    whereClauses.push(eq(actionData.actionType, actionType));
+  }
+
+  const rows = await drizzleDb
+    .select({
+      userId: actionData.userId,
+      totalActions: sum(actionData.hasPerformed).mapWith(Number),
+    })
+    .from(actionData)
+    .where(and(...whereClauses))
+    .groupBy(actionData.userId)
+    .orderBy(desc(sum(actionData.hasPerformed)))
+    .limit(Math.min(limit, 25));
+
+  const entries: LeaderboardEntry[] = [];
+
+  // Try to resolve display names from Discord
+  let guild: Guild | null = null;
+  try {
+    guild = discordClient.guilds.cache.get(locationId) ?? null;
+  } catch {
+    // bot may not be in this guild
+  }
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    let displayName: string | null = null;
+
+    if (guild && row.userId) {
+      try {
+        const member = await guild.members.fetch(row.userId);
+        displayName = member.displayName ?? member.user.displayName ?? null;
+      } catch {
+        // user may have left the guild or fetch failed
+      }
+    }
+
+    entries.push({
+      rank: i + 1,
+      userId: row.userId,
+      displayName,
+      anonymousLabel: hashUserId(row.userId),
+      totalActions: row.totalActions ?? 0,
+    });
+  }
+
+  return { locationId, actionType: actionType ?? null, entries };
+}

--- a/src/utilities/leaderboard.ts
+++ b/src/utilities/leaderboard.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import type { Client, Guild } from "discord.js";
 import { drizzleDb } from "../db/connector.js";
 import { actionData } from "../db/schema.js";
-import { eq, and, desc, sum, type SQL } from "drizzle-orm";
+import { eq, and, desc, sum, gt, type SQL } from "drizzle-orm";
 
 export interface LeaderboardEntry {
   rank: number;
@@ -46,6 +46,7 @@ export async function getLeaderboard(opts: {
     .from(actionData)
     .where(and(...whereClauses))
     .groupBy(actionData.userId)
+    .having(gt(sum(actionData.hasPerformed), 0))
     .orderBy(desc(sum(actionData.hasPerformed)))
     .limit(Math.min(limit, 25));
 

--- a/src/utilities/leaderboard.ts
+++ b/src/utilities/leaderboard.ts
@@ -51,23 +51,30 @@ export async function getLeaderboard(opts: {
   // Try to resolve display names from Discord
   let guild: Guild | null = null;
   try {
-    guild = discordClient.guilds.cache.get(locationId) ?? null;
+    guild = await discordClient.guilds.fetch(locationId);
   } catch {
     // bot may not be in this guild
   }
 
+  // Pre-fetch all guild members in a single API call to avoid N+1 serial fetches
+  const displayNameByUserId = new Map<string, string | null>();
+  if (guild) {
+    try {
+      const members = await guild.members.fetch();
+      for (const [userId, member] of members) {
+        displayNameByUserId.set(
+          userId,
+          member.displayName ?? member.user.displayName ?? null,
+        );
+      }
+    } catch {
+      // failed to fetch members, proceed without display names
+    }
+  }
+
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
-    let displayName: string | null = null;
-
-    if (guild && row.userId) {
-      try {
-        const member = await guild.members.fetch(row.userId);
-        displayName = member.displayName ?? member.user.displayName ?? null;
-      } catch {
-        // user may have left the guild or fetch failed
-      }
-    }
+    const displayName = displayNameByUserId.get(row.userId) ?? null;
 
     entries.push({
       rank: i + 1,

--- a/src/utilities/leaderboard.ts
+++ b/src/utilities/leaderboard.ts
@@ -56,11 +56,12 @@ export async function getLeaderboard(opts: {
     // bot may not be in this guild
   }
 
-  // Pre-fetch all guild members in a single API call to avoid N+1 serial fetches
+  // Fetch only the members we need for the leaderboard entries
   const displayNameByUserId = new Map<string, string | null>();
-  if (guild) {
+  if (guild && rows.length > 0) {
+    const userIds = rows.map((r) => r.userId);
     try {
-      const members = await guild.members.fetch();
+      const members = await guild.members.fetch({ user: userIds });
       for (const [userId, member] of members) {
         displayNameByUserId.set(
           userId,

--- a/src/utilities/leaderboard.ts
+++ b/src/utilities/leaderboard.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
-import { Client, Guild } from "discord.js";
+import type { Client, Guild } from "discord.js";
 import { drizzleDb } from "../db/connector.js";
 import { actionData } from "../db/schema.js";
-import { eq, and, desc, sum } from "drizzle-orm";
+import { eq, and, desc, sum, type SQL } from "drizzle-orm";
 
 export interface LeaderboardEntry {
   rank: number;
@@ -30,7 +30,7 @@ export async function getLeaderboard(opts: {
 }): Promise<LeaderboardResult> {
   const { locationId, actionType, limit = 10, discordClient } = opts;
 
-  const whereClauses = [];
+  const whereClauses: SQL[] = [];
   if (locationId) {
     whereClauses.push(eq(actionData.locationId, locationId));
   }

--- a/src/utilities/leaderboard.ts
+++ b/src/utilities/leaderboard.ts
@@ -1,8 +1,8 @@
-import { createHash } from "node:crypto";
 import type { Client, Guild } from "discord.js";
 import { drizzleDb } from "../db/connector.js";
-import { actionData } from "../db/schema.js";
-import { eq, and, desc, sum, gt, type SQL } from "drizzle-orm";
+import { actionData, leaderboardConsent } from "../db/schema.js";
+import { eq, and, desc, sum, gt, inArray, type SQL } from "drizzle-orm";
+import { hashUserId } from "./crypto.js";
 
 export interface LeaderboardEntry {
   rank: number;
@@ -16,10 +16,6 @@ export interface LeaderboardResult {
   locationId: string | null;
   actionType: string | null;
   entries: LeaderboardEntry[];
-}
-
-function hashUserId(userId: string): string {
-  return createHash("sha256").update(userId).digest("hex").slice(0, 4);
 }
 
 export async function getLeaderboard(opts: {
@@ -78,15 +74,35 @@ export async function getLeaderboard(opts: {
     }
   }
 
+  // Look up consent records for all hashed user IDs
+  const consentDisplayNames = new Map<string, string>();
+  try {
+    const hashedIds = rows.map((r) => hashUserId(r.userId));
+    const consentRows = await drizzleDb
+      .select({
+        hashedUserId: leaderboardConsent.hashedUserId,
+        displayName: leaderboardConsent.displayName,
+      })
+      .from(leaderboardConsent)
+      .where(inArray(leaderboardConsent.hashedUserId, hashedIds));
+    for (const row of consentRows) {
+      consentDisplayNames.set(row.hashedUserId, row.displayName);
+    }
+  } catch {
+    // failed to fetch consent, proceed without display names
+  }
+
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
-    const displayName = displayNameByUserId.get(row.userId) ?? null;
+    const hashed = hashUserId(row.userId);
+    const consentName = consentDisplayNames.get(hashed) ?? null;
+    const displayName = consentName ?? displayNameByUserId.get(row.userId) ?? null;
 
     entries.push({
       rank: i + 1,
       userId: row.userId,
       displayName,
-      anonymousLabel: hashUserId(row.userId),
+      anonymousLabel: hashed,
       totalActions: row.totalActions ?? 0,
     });
   }

--- a/src/utilities/leaderboard.ts
+++ b/src/utilities/leaderboard.ts
@@ -22,9 +22,10 @@ export async function getLeaderboard(opts: {
   locationId?: string;
   actionType?: string;
   limit?: number;
+  currentUserId?: string;
   discordClient: Client;
 }): Promise<LeaderboardResult> {
-  const { locationId, actionType, limit = 10, discordClient } = opts;
+  const { locationId, actionType, limit = 10, currentUserId, discordClient } = opts;
 
   const whereClauses: SQL[] = [];
   if (locationId) {
@@ -46,23 +47,16 @@ export async function getLeaderboard(opts: {
     .orderBy(desc(sum(actionData.hasPerformed)))
     .limit(Math.min(limit, 25));
 
-  const entries: LeaderboardEntry[] = [];
-
-  // Only resolve display names when scoped to a specific guild
-  let guild: Guild | null = null;
-  if (locationId) {
-    try {
-      guild = await discordClient.guilds.fetch(locationId);
-    } catch {
-      // bot may not be in this guild
-    }
+  if (rows.length === 0) {
+    return { locationId: locationId ?? null, actionType: actionType ?? null, entries: [] };
   }
 
+  // Resolve guild display names when scoped to a specific guild
   const displayNameByUserId = new Map<string, string | null>();
-  if (guild && rows.length > 0) {
-    const userIds = rows.map((r) => r.userId);
+  if (locationId) {
     try {
-      const members = await guild.members.fetch({ user: userIds });
+      const guild: Guild = await discordClient.guilds.fetch(locationId);
+      const members = await guild.members.fetch({ user: rows.map((r) => r.userId) });
       for (const [userId, member] of members) {
         displayNameByUserId.set(
           userId,
@@ -70,7 +64,7 @@ export async function getLeaderboard(opts: {
         );
       }
     } catch {
-      // failed to fetch members, proceed without display names
+      // bot may not be in this guild, or failed to fetch members
     }
   }
 
@@ -92,19 +86,88 @@ export async function getLeaderboard(opts: {
     // failed to fetch consent, proceed without display names
   }
 
-  for (let i = 0; i < rows.length; i++) {
-    const row = rows[i];
+  const entries: LeaderboardEntry[] = rows.map((row, i) => {
     const hashed = hashUserId(row.userId);
     const consentName = consentDisplayNames.get(hashed) ?? null;
     const displayName = consentName ?? displayNameByUserId.get(row.userId) ?? null;
 
-    entries.push({
+    return {
       rank: i + 1,
       userId: row.userId,
       displayName,
-      anonymousLabel: hashed,
+      anonymousLabel: hashed.slice(0, 6),
       totalActions: row.totalActions ?? 0,
-    });
+    };
+  });
+
+  // If current user is not in the top N, add them at the bottom
+  if (currentUserId && !entries.some((e) => e.userId === currentUserId)) {
+    try {
+      const userRows = await drizzleDb
+        .select({
+          totalActions: sum(actionData.hasPerformed).mapWith(Number),
+        })
+        .from(actionData)
+        .where(and(...whereClauses, eq(actionData.userId, currentUserId)))
+        .groupBy(actionData.userId)
+        .having(gt(sum(actionData.hasPerformed), 0));
+
+      const userTotal = userRows[0]?.totalActions ?? 0;
+
+      if (userTotal > 0) {
+        // Count how many have more actions to determine rank
+        const rankRows = await drizzleDb
+          .select({
+            count: sum(actionData.hasPerformed).mapWith(Number),
+          })
+          .from(actionData)
+          .where(and(...whereClauses))
+          .groupBy(actionData.userId)
+          .having(gt(sum(actionData.hasPerformed), userTotal));
+
+        const rank = rankRows.length + 1;
+
+        const hashed = hashUserId(currentUserId);
+        let displayName = consentDisplayNames.get(hashed) ?? null;
+
+        // Look up consent specifically if not in the top N map
+        if (!displayName) {
+          try {
+            const consentRow = await drizzleDb
+              .select({ displayName: leaderboardConsent.displayName })
+              .from(leaderboardConsent)
+              .where(eq(leaderboardConsent.hashedUserId, hashed))
+              .limit(1);
+            if (consentRow.length > 0) {
+              displayName = consentRow[0].displayName;
+            }
+          } catch {
+            // failed to fetch consent
+          }
+        }
+
+        // Try guild display name if not consented
+        if (!displayName && locationId) {
+          try {
+            const guild: Guild = await discordClient.guilds.fetch(locationId);
+            const member = await guild.members.fetch(currentUserId);
+            displayName = member.displayName ?? member.user.displayName ?? null;
+          } catch {
+            // couldn't resolve guild name
+          }
+        }
+
+        entries.push({
+          rank,
+          userId: currentUserId,
+          displayName,
+          anonymousLabel: hashed.slice(0, 6),
+          totalActions: userTotal,
+        });
+      }
+    } catch {
+      // failed to include current user, proceed without
+    }
   }
 
   return { locationId: locationId ?? null, actionType: actionType ?? null, entries };

--- a/src/utilities/leaderboard.ts
+++ b/src/utilities/leaderboard.ts
@@ -13,7 +13,7 @@ export interface LeaderboardEntry {
 }
 
 export interface LeaderboardResult {
-  locationId: string;
+  locationId: string | null;
   actionType: string | null;
   entries: LeaderboardEntry[];
 }
@@ -23,14 +23,17 @@ function hashUserId(userId: string): string {
 }
 
 export async function getLeaderboard(opts: {
-  locationId: string;
+  locationId?: string;
   actionType?: string;
   limit?: number;
   discordClient: Client;
 }): Promise<LeaderboardResult> {
   const { locationId, actionType, limit = 10, discordClient } = opts;
 
-  const whereClauses = [eq(actionData.locationId, locationId)];
+  const whereClauses = [];
+  if (locationId) {
+    whereClauses.push(eq(actionData.locationId, locationId));
+  }
   if (actionType) {
     whereClauses.push(eq(actionData.actionType, actionType));
   }
@@ -48,15 +51,16 @@ export async function getLeaderboard(opts: {
 
   const entries: LeaderboardEntry[] = [];
 
-  // Try to resolve display names from Discord
+  // Only resolve display names when scoped to a specific guild
   let guild: Guild | null = null;
-  try {
-    guild = await discordClient.guilds.fetch(locationId);
-  } catch {
-    // bot may not be in this guild
+  if (locationId) {
+    try {
+      guild = await discordClient.guilds.fetch(locationId);
+    } catch {
+      // bot may not be in this guild
+    }
   }
 
-  // Fetch only the members we need for the leaderboard entries
   const displayNameByUserId = new Map<string, string | null>();
   if (guild && rows.length > 0) {
     const userIds = rows.map((r) => r.userId);
@@ -86,5 +90,5 @@ export async function getLeaderboard(opts: {
     });
   }
 
-  return { locationId, actionType: actionType ?? null, entries };
+  return { locationId: locationId ?? null, actionType: actionType ?? null, entries };
 }

--- a/tests/commands/leaderboard.test.ts
+++ b/tests/commands/leaderboard.test.ts
@@ -1,0 +1,118 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { mockInteraction } from "../helpers/mockInteraction.js";
+
+vi.mock("../../src/utilities/leaderboard.js", () => ({
+  getLeaderboard: vi.fn(),
+}));
+
+import { command } from "../../src/commands/slash/leaderboard.js";
+import { getLeaderboard } from "../../src/utilities/leaderboard.js";
+
+describe("/leaderboard command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns message when no entries", async () => {
+    (getLeaderboard as any).mockResolvedValue({
+      locationId: "guild-1",
+      actionType: null,
+      entries: [],
+    });
+
+    const interaction = mockInteraction({ guildId: "guild-1" });
+    await command.execute(interaction as any);
+
+    expect(interaction.__calls.editedReplies).toHaveLength(1);
+    expect(interaction.__calls.editedReplies[0]).toBe(
+      "No actions recorded here yet.",
+    );
+  });
+
+  it("returns ephemeral embed with entries", async () => {
+    const entries = Array.from({ length: 3 }, (_, i) => ({
+      rank: i + 1,
+      userId: `user-${i + 1}`,
+      displayName: i === 0 ? "CoolDude" : null,
+      anonymousLabel: "abcd",
+      totalActions: 100 - i * 10,
+    }));
+
+    (getLeaderboard as any).mockResolvedValue({
+      locationId: "guild-1",
+      actionType: null,
+      entries,
+    });
+
+    const interaction = mockInteraction({
+      guildId: "guild-1",
+      user: { id: "user-1" },
+    });
+    await command.execute(interaction as any);
+
+    expect(interaction.__calls.editedReplies).toHaveLength(1);
+    const payload = interaction.__calls.editedReplies[0];
+    expect(payload.embeds).toHaveLength(1);
+    expect(payload.embeds[0].data.description).toContain("CoolDude");
+    expect(payload.embeds[0].data.description).toContain("(you)");
+  });
+
+  it("uses channelId when guildId is null (DM context)", async () => {
+    (getLeaderboard as any).mockResolvedValue({
+      locationId: "dm-123",
+      actionType: null,
+      entries: [],
+    });
+
+    const interaction = mockInteraction({ channelId: "dm-123" });
+    interaction.guildId = null;
+    await command.execute(interaction as any);
+
+    expect(getLeaderboard).toHaveBeenCalledWith(
+      expect.objectContaining({ locationId: "dm-123" }),
+    );
+  });
+
+  it("passes actionType option when provided", async () => {
+    (getLeaderboard as any).mockResolvedValue({
+      locationId: "guild-1",
+      actionType: "pet",
+      entries: [],
+    });
+
+    const interaction = mockInteraction({
+      guildId: "guild-1",
+      options: { action: "pet" },
+    });
+    await command.execute(interaction as any);
+
+    expect(getLeaderboard).toHaveBeenCalledWith(
+      expect.objectContaining({ actionType: "pet" }),
+    );
+  });
+
+  it("marks the calling user with (you) in the embed", async () => {
+    const entries = [
+      { rank: 1, userId: "user-2", displayName: "Other", anonymousLabel: "abcd", totalActions: 50 },
+      { rank: 2, userId: "user-1", displayName: "Me", anonymousLabel: "efgh", totalActions: 30 },
+    ];
+
+    (getLeaderboard as any).mockResolvedValue({
+      locationId: "guild-1",
+      actionType: null,
+      entries,
+    });
+
+    const interaction = mockInteraction({
+      guildId: "guild-1",
+      user: { id: "user-1" },
+    });
+    await command.execute(interaction as any);
+
+    const description =
+      interaction.__calls.editedReplies[0].embeds[0].data.description;
+    expect(description).toContain("Other");
+    expect(description).not.toContain("Other — 50 **(you)**");
+    expect(description).toContain("Me — 30 **(you)**");
+  });
+});

--- a/tests/http/routes/leaderboard.test.ts
+++ b/tests/http/routes/leaderboard.test.ts
@@ -31,15 +31,6 @@ describe("GET /api/leaderboard", () => {
     vi.clearAllMocks();
   });
 
-  it("returns 400 when locationId is missing", async () => {
-    const handler = leaderboardHandler(mockClient);
-    const req = { query: {} } as any;
-    const res = makeRes();
-    await handler(req, res);
-    expect(res._status).toBe(400);
-    expect(res._body.error).toBe("missing_locationId");
-  });
-
   it("returns 400 for invalid actionType", async () => {
     const handler = leaderboardHandler(mockClient);
     const req = { query: { locationId: "g1", actionType: "invalid" } } as any;
@@ -48,7 +39,27 @@ describe("GET /api/leaderboard", () => {
     expect(res._status).toBe(400);
   });
 
-  it("returns leaderboard data on success", async () => {
+  it("returns global leaderboard when no locationId", async () => {
+    (getLeaderboard as any).mockResolvedValue({
+      locationId: null,
+      actionType: null,
+      entries: [
+        { rank: 1, userId: "u1", displayName: null, anonymousLabel: "abcd", totalActions: 100 },
+      ],
+    });
+
+    const handler = leaderboardHandler(mockClient);
+    const req = { query: {} } as any;
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(getLeaderboard).toHaveBeenCalledWith(
+      expect.not.objectContaining({ locationId: expect.anything() }),
+    );
+    expect(res._body.entries).toHaveLength(1);
+  });
+
+  it("returns leaderboard data for a specific location", async () => {
     (getLeaderboard as any).mockResolvedValue({
       locationId: "g1",
       actionType: null,
@@ -70,6 +81,9 @@ describe("GET /api/leaderboard", () => {
     const res = makeRes();
     await handler(req, res);
 
+    expect(getLeaderboard).toHaveBeenCalledWith(
+      expect.objectContaining({ locationId: "g1" }),
+    );
     expect(res._body.entries).toHaveLength(1);
     expect(res._body.entries[0].rank).toBe(1);
   });

--- a/tests/http/routes/leaderboard.test.ts
+++ b/tests/http/routes/leaderboard.test.ts
@@ -9,6 +9,8 @@ vi.mock("../../../src/logger.js", () => ({ default: { error: vi.fn() } }));
 import leaderboardHandler from "../../../src/http/routes/leaderboard.js";
 import { getLeaderboard } from "../../../src/utilities/leaderboard.js";
 
+const mockClient = {} as any;
+
 function makeRes() {
   const res: any = {};
   res._status = 200;
@@ -30,28 +32,20 @@ describe("GET /api/leaderboard", () => {
   });
 
   it("returns 400 when locationId is missing", async () => {
+    const handler = leaderboardHandler(mockClient);
     const req = { query: {} } as any;
     const res = makeRes();
-    await leaderboardHandler(req, res);
+    await handler(req, res);
     expect(res._status).toBe(400);
     expect(res._body.error).toBe("missing_locationId");
   });
 
   it("returns 400 for invalid actionType", async () => {
+    const handler = leaderboardHandler(mockClient);
     const req = { query: { locationId: "g1", actionType: "invalid" } } as any;
     const res = makeRes();
-    await leaderboardHandler(req, res);
+    await handler(req, res);
     expect(res._status).toBe(400);
-  });
-
-  it("returns 503 when client is missing", async () => {
-    const req = {
-      query: { locationId: "g1" },
-      app: { locals: {} },
-    } as any;
-    const res = makeRes();
-    await leaderboardHandler(req, res);
-    expect(res._status).toBe(503);
   });
 
   it("returns leaderboard data on success", async () => {
@@ -69,12 +63,12 @@ describe("GET /api/leaderboard", () => {
       ],
     });
 
+    const handler = leaderboardHandler(mockClient);
     const req = {
       query: { locationId: "g1" },
-      app: { locals: { client: {} } },
     } as any;
     const res = makeRes();
-    await leaderboardHandler(req, res);
+    await handler(req, res);
 
     expect(res._body.entries).toHaveLength(1);
     expect(res._body.entries[0].rank).toBe(1);
@@ -87,12 +81,12 @@ describe("GET /api/leaderboard", () => {
       entries: [],
     });
 
+    const handler = leaderboardHandler(mockClient);
     const req = {
       query: { locationId: "g1", limit: "100" },
-      app: { locals: { client: {} } },
     } as any;
     const res = makeRes();
-    await leaderboardHandler(req, res);
+    await handler(req, res);
 
     expect(getLeaderboard).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 25 }),
@@ -106,12 +100,12 @@ describe("GET /api/leaderboard", () => {
       entries: [],
     });
 
+    const handler = leaderboardHandler(mockClient);
     const req = {
       query: { locationId: "g1" },
-      app: { locals: { client: {} } },
     } as any;
     const res = makeRes();
-    await leaderboardHandler(req, res);
+    await handler(req, res);
 
     expect(getLeaderboard).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 10 }),

--- a/tests/http/routes/leaderboard.test.ts
+++ b/tests/http/routes/leaderboard.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../src/utilities/leaderboard.js", () => ({
+  getLeaderboard: vi.fn(),
+}));
+
+vi.mock("../../../src/logger.js", () => ({ default: { error: vi.fn() } }));
+
+import leaderboardHandler from "../../../src/http/routes/leaderboard.js";
+import { getLeaderboard } from "../../../src/utilities/leaderboard.js";
+
+function makeRes() {
+  const res: any = {};
+  res._status = 200;
+  res._body = undefined;
+  res.status = vi.fn((code: number) => {
+    res._status = code;
+    return res;
+  });
+  res.json = vi.fn((body: any) => {
+    res._body = body;
+    return res;
+  });
+  return res;
+}
+
+describe("GET /api/leaderboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when locationId is missing", async () => {
+    const req = { query: {} } as any;
+    const res = makeRes();
+    await leaderboardHandler(req, res);
+    expect(res._status).toBe(400);
+    expect(res._body.error).toBe("missing_locationId");
+  });
+
+  it("returns 400 for invalid actionType", async () => {
+    const req = { query: { locationId: "g1", actionType: "invalid" } } as any;
+    const res = makeRes();
+    await leaderboardHandler(req, res);
+    expect(res._status).toBe(400);
+  });
+
+  it("returns 503 when client is missing", async () => {
+    const req = {
+      query: { locationId: "g1" },
+      app: { locals: {} },
+    } as any;
+    const res = makeRes();
+    await leaderboardHandler(req, res);
+    expect(res._status).toBe(503);
+  });
+
+  it("returns leaderboard data on success", async () => {
+    (getLeaderboard as any).mockResolvedValue({
+      locationId: "g1",
+      actionType: null,
+      entries: [
+        {
+          rank: 1,
+          userId: "u1",
+          displayName: null,
+          anonymousLabel: "abcd",
+          totalActions: 42,
+        },
+      ],
+    });
+
+    const req = {
+      query: { locationId: "g1" },
+      app: { locals: { client: {} } },
+    } as any;
+    const res = makeRes();
+    await leaderboardHandler(req, res);
+
+    expect(res._body.entries).toHaveLength(1);
+    expect(res._body.entries[0].rank).toBe(1);
+  });
+
+  it("caps limit at 25", async () => {
+    (getLeaderboard as any).mockResolvedValue({
+      locationId: "g1",
+      actionType: null,
+      entries: [],
+    });
+
+    const req = {
+      query: { locationId: "g1", limit: "100" },
+      app: { locals: { client: {} } },
+    } as any;
+    const res = makeRes();
+    await leaderboardHandler(req, res);
+
+    expect(getLeaderboard).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 25 }),
+    );
+  });
+
+  it("defaults limit to 10", async () => {
+    (getLeaderboard as any).mockResolvedValue({
+      locationId: "g1",
+      actionType: null,
+      entries: [],
+    });
+
+    const req = {
+      query: { locationId: "g1" },
+      app: { locals: { client: {} } },
+    } as any;
+    const res = makeRes();
+    await leaderboardHandler(req, res);
+
+    expect(getLeaderboard).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10 }),
+    );
+  });
+});

--- a/tests/http/routes/leaderboardConsent.test.ts
+++ b/tests/http/routes/leaderboardConsent.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import supertest from "supertest";
+
+const { selectMock, insertMock, deleteMock } = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  insertMock: vi.fn(),
+  deleteMock: vi.fn(),
+}));
+
+vi.mock("../../../src/db/connector.js", () => ({
+  drizzleDb: {
+    select: selectMock,
+    insert: insertMock,
+    delete: deleteMock,
+  },
+}));
+vi.mock("../../../src/db/schema.js", () => ({
+  leaderboardConsent: {
+    hashedUserId: Symbol("hashed_user_id"),
+    displayName: Symbol("display_name"),
+    createdAt: Symbol("createdAt"),
+    updatedAt: Symbol("updatedAt"),
+  },
+}));
+vi.mock("../../../src/logger.js", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+import { createApp } from "../../../src/http/expressServer.js";
+
+describe("/api/leaderboardConsent/:hashedUserId", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.INTERNAL_API_SECRET;
+    app = createApp();
+  });
+
+  describe("GET", () => {
+    it("returns enabled false when no row exists", async () => {
+      (selectMock as any).mockImplementation(() => ({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([]) }),
+        }),
+      }));
+
+      const res = await supertest(app).get("/api/leaderboardConsent/abc123").expect(200);
+      expect(res.body).toEqual({ enabled: false, displayName: null });
+    });
+
+    it("returns enabled true with displayName when row exists", async () => {
+      (selectMock as any).mockImplementation(() => ({
+        from: () => ({
+          where: () => ({
+            limit: () => Promise.resolve([{ hashedUserId: "abc123", displayName: "TestUser" }]),
+          }),
+        }),
+      }));
+
+      const res = await supertest(app).get("/api/leaderboardConsent/abc123").expect(200);
+      expect(res.body).toEqual({ enabled: true, displayName: "TestUser" });
+    });
+
+    it("returns 500 on DB error", async () => {
+      (selectMock as any).mockImplementation(() => {
+        throw new Error("db-failure");
+      });
+      await supertest(app).get("/api/leaderboardConsent/abc123").expect(500);
+    });
+  });
+
+  describe("POST", () => {
+    it("inserts or upserts consent row", async () => {
+      const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+      const values = vi.fn(() => ({ onConflictDoUpdate }));
+      (insertMock as any).mockReturnValue({ values });
+
+      const res = await supertest(app)
+        .post("/api/leaderboardConsent/abc123")
+        .send({ displayName: "MyName" })
+        .expect(200);
+
+      expect(res.body).toEqual({ ok: true });
+      expect(insertMock).toHaveBeenCalled();
+      expect(values).toHaveBeenCalled();
+      expect(onConflictDoUpdate).toHaveBeenCalled();
+    });
+
+    it("returns 400 when displayName is missing", async () => {
+      const res = await supertest(app)
+        .post("/api/leaderboardConsent/abc123")
+        .send({})
+        .expect(400);
+      expect(res.body).toEqual({ error: "displayName_required" });
+    });
+
+    it("returns 400 when displayName is whitespace only", async () => {
+      const res = await supertest(app)
+        .post("/api/leaderboardConsent/abc123")
+        .send({ displayName: "   " })
+        .expect(400);
+      expect(res.body).toEqual({ error: "displayName_required" });
+    });
+
+    it("returns 500 on DB error", async () => {
+      (insertMock as any).mockImplementation(() => {
+        throw new Error("db-failure");
+      });
+      await supertest(app)
+        .post("/api/leaderboardConsent/abc123")
+        .send({ displayName: "MyName" })
+        .expect(500);
+    });
+  });
+
+  describe("DELETE", () => {
+    it("removes consent row", async () => {
+      const where = vi.fn().mockResolvedValue(undefined);
+      (deleteMock as any).mockReturnValue({ where });
+
+      const res = await supertest(app)
+        .delete("/api/leaderboardConsent/abc123")
+        .expect(200);
+
+      expect(res.body).toEqual({ ok: true });
+      expect(deleteMock).toHaveBeenCalled();
+      expect(where).toHaveBeenCalled();
+    });
+
+    it("returns 500 on DB error", async () => {
+      (deleteMock as any).mockImplementation(() => {
+        throw new Error("db-failure");
+      });
+      await supertest(app).delete("/api/leaderboardConsent/abc123").expect(500);
+    });
+  });
+});

--- a/tests/utilities/leaderboard.test.ts
+++ b/tests/utilities/leaderboard.test.ts
@@ -230,4 +230,24 @@ describe("getLeaderboard", () => {
 
     expect(result.entries[0].displayName).toBe("FallbackName");
   });
+
+  it("works without locationId for global scope", async () => {
+    (drizzleDb.select as any).mockReturnValue(
+      makeChain([
+        { userId: "user-1", totalActions: 200 },
+        { userId: "user-2", totalActions: 150 },
+      ]),
+    );
+
+    const result = await getLeaderboard({
+      discordClient: noGuildClient,
+    });
+
+    expect(result.locationId).toBeNull();
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries[0].totalActions).toBe(200);
+    // No guild to resolve names from, so all entries are anonymous
+    expect(result.entries[0].displayName).toBeNull();
+    expect(result.entries[0].anonymousLabel).toHaveLength(4);
+  });
 });

--- a/tests/utilities/leaderboard.test.ts
+++ b/tests/utilities/leaderboard.test.ts
@@ -17,6 +17,10 @@ vi.mock("../../src/db/schema.js", () => ({
     actionType: "actionType",
     hasPerformed: "hasPerformed",
   },
+  leaderboardConsent: {
+    hashedUserId: "hashedUserId",
+    displayName: "displayName",
+  },
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -26,6 +30,7 @@ vi.mock("drizzle-orm", () => ({
   desc: vi.fn((col) => ({ type: "desc", col })),
   sum: sumMock,
   gt: vi.fn((a, b) => ({ type: "gt", a, b })),
+  inArray: vi.fn((a, b) => ({ type: "inArray", a, b })),
 }));
 
 vi.mock("../../src/logger.js", () => ({ default: { error: vi.fn() } }));
@@ -46,6 +51,14 @@ describe("getLeaderboard", () => {
     return chain;
   }
 
+  function makeConsentChain(resolvedRows: any[]) {
+    const chain: any = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(resolvedRows),
+    };
+    return chain;
+  }
+
   const noGuildClient = {
     guilds: {
       cache: new Map(),
@@ -59,7 +72,14 @@ describe("getLeaderboard", () => {
   });
 
   it("returns empty entries when no data exists", async () => {
-    (drizzleDb.select as any).mockReturnValue(makeChain([]));
+    let callCount = 0;
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([]);
+      }
+      return makeConsentChain([]);
+    });
 
     const result = await getLeaderboard({
       locationId: "guild-1",
@@ -72,12 +92,17 @@ describe("getLeaderboard", () => {
   });
 
   it("returns ranked entries with anonymous labels when bot not in guild", async () => {
-    (drizzleDb.select as any).mockReturnValue(
-      makeChain([
-        { userId: "user-1", totalActions: 100 },
-        { userId: "user-2", totalActions: 50 },
-      ]),
-    );
+    let callCount = 0;
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([
+          { userId: "user-1", totalActions: 100 },
+          { userId: "user-2", totalActions: 50 },
+        ]);
+      }
+      return makeConsentChain([]);
+    });
 
     const result = await getLeaderboard({
       locationId: "guild-1",
@@ -88,14 +113,19 @@ describe("getLeaderboard", () => {
     expect(result.entries[0].rank).toBe(1);
     expect(result.entries[0].userId).toBe("user-1");
     expect(result.entries[0].displayName).toBeNull();
-    expect(result.entries[0].anonymousLabel).toHaveLength(4);
+    expect(result.entries[0].anonymousLabel).toHaveLength(6);
     expect(result.entries[1].rank).toBe(2);
   });
 
   it("filters by actionType when provided", async () => {
-    (drizzleDb.select as any).mockReturnValue(
-      makeChain([{ userId: "user-1", totalActions: 20 }]),
-    );
+    let callCount = 0;
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([{ userId: "user-1", totalActions: 20 }]);
+      }
+      return makeConsentChain([]);
+    });
 
     const result = await getLeaderboard({
       locationId: "guild-1",
@@ -109,8 +139,15 @@ describe("getLeaderboard", () => {
   });
 
   it("respects the limit parameter", async () => {
+    let callCount = 0;
     const chain = makeChain([]);
-    (drizzleDb.select as any).mockReturnValue(chain);
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return chain;
+      }
+      return makeConsentChain([]);
+    });
 
     await getLeaderboard({
       locationId: "guild-1",
@@ -122,8 +159,15 @@ describe("getLeaderboard", () => {
   });
 
   it("caps limit at 25", async () => {
+    let callCount = 0;
     const chain = makeChain([]);
-    (drizzleDb.select as any).mockReturnValue(chain);
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return chain;
+      }
+      return makeConsentChain([]);
+    });
 
     await getLeaderboard({
       locationId: "guild-1",
@@ -135,8 +179,15 @@ describe("getLeaderboard", () => {
   });
 
   it("defaults limit to 10", async () => {
+    let callCount = 0;
     const chain = makeChain([]);
-    (drizzleDb.select as any).mockReturnValue(chain);
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return chain;
+      }
+      return makeConsentChain([]);
+    });
 
     await getLeaderboard({
       locationId: "guild-1",
@@ -152,12 +203,17 @@ describe("getLeaderboard", () => {
       guilds: { cache: new Map(), fetch: guildFetch },
     } as any;
 
-    (drizzleDb.select as any).mockReturnValue(
-      makeChain([
-        { userId: "user-1", totalActions: 100 },
-        { userId: "user-2", totalActions: 50 },
-      ]),
-    );
+    let callCount = 0;
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([
+          { userId: "user-1", totalActions: 100 },
+          { userId: "user-2", totalActions: 50 },
+        ]);
+      }
+      return makeConsentChain([]);
+    });
 
     const result = await getLeaderboard({
       locationId: "guild-1",
@@ -189,9 +245,14 @@ describe("getLeaderboard", () => {
       guilds: { cache: new Map(), fetch: guildFetch },
     } as any;
 
-    (drizzleDb.select as any).mockReturnValue(
-      makeChain([{ userId: "user-1", totalActions: 100 }]),
-    );
+    let callCount = 0;
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([{ userId: "user-1", totalActions: 100 }]);
+      }
+      return makeConsentChain([]);
+    });
 
     const result = await getLeaderboard({
       locationId: "guild-1",
@@ -221,9 +282,14 @@ describe("getLeaderboard", () => {
       guilds: { cache: new Map(), fetch: guildFetch },
     } as any;
 
-    (drizzleDb.select as any).mockReturnValue(
-      makeChain([{ userId: "user-1", totalActions: 100 }]),
-    );
+    let callCount = 0;
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([{ userId: "user-1", totalActions: 100 }]);
+      }
+      return makeConsentChain([]);
+    });
 
     const result = await getLeaderboard({
       locationId: "guild-1",
@@ -234,12 +300,17 @@ describe("getLeaderboard", () => {
   });
 
   it("works without locationId for global scope", async () => {
-    (drizzleDb.select as any).mockReturnValue(
-      makeChain([
-        { userId: "user-1", totalActions: 200 },
-        { userId: "user-2", totalActions: 150 },
-      ]),
-    );
+    let callCount = 0;
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([
+          { userId: "user-1", totalActions: 200 },
+          { userId: "user-2", totalActions: 150 },
+        ]);
+      }
+      return makeConsentChain([]);
+    });
 
     const result = await getLeaderboard({
       discordClient: noGuildClient,
@@ -250,6 +321,37 @@ describe("getLeaderboard", () => {
     expect(result.entries[0].totalActions).toBe(200);
     // No guild to resolve names from, so all entries are anonymous
     expect(result.entries[0].displayName).toBeNull();
-    expect(result.entries[0].anonymousLabel).toHaveLength(4);
+    expect(result.entries[0].anonymousLabel).toHaveLength(6);
+  });
+
+  it("uses consent display name over guild display name", async () => {
+    const guildFetch = vi.fn().mockResolvedValue({
+      members: {
+        fetch: vi.fn().mockResolvedValue(
+          new Map([
+            ["user-1", { displayName: "GuildName", user: { displayName: "notused" } }],
+          ]),
+        ),
+      },
+    });
+    const client = { guilds: { cache: new Map(), fetch: guildFetch } } as any;
+
+    let callCount = 0;
+    (drizzleDb.select as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return makeChain([{ userId: "user-1", totalActions: 100 }]);
+      }
+      return makeConsentChain([
+        { hashedUserId: "c6c289", displayName: "ConsentName" },
+      ]);
+    });
+
+    const result = await getLeaderboard({
+      locationId: "guild-1",
+      discordClient: client,
+    });
+
+    expect(result.entries[0].displayName).toBe("ConsentName");
   });
 });

--- a/tests/utilities/leaderboard.test.ts
+++ b/tests/utilities/leaderboard.test.ts
@@ -25,6 +25,7 @@ vi.mock("drizzle-orm", () => ({
   and: vi.fn((...args: unknown[]) => args),
   desc: vi.fn((col) => ({ type: "desc", col })),
   sum: sumMock,
+  gt: vi.fn((a, b) => ({ type: "gt", a, b })),
 }));
 
 vi.mock("../../src/logger.js", () => ({ default: { error: vi.fn() } }));
@@ -38,6 +39,7 @@ describe("getLeaderboard", () => {
       from: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
       groupBy: vi.fn().mockReturnThis(),
+      having: vi.fn().mockReturnThis(),
       orderBy: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue(resolvedRows),
     };

--- a/tests/utilities/leaderboard.test.ts
+++ b/tests/utilities/leaderboard.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { sumMock } = vi.hoisted(() => ({
+  sumMock: vi.fn(),
+}));
+
+vi.mock("../../src/db/connector.js", () => ({
+  drizzleDb: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/db/schema.js", () => ({
+  actionData: {
+    userId: "userId",
+    locationId: "locationId",
+    actionType: "actionType",
+    hasPerformed: "hasPerformed",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  sql: { raw: (s: string) => s },
+  eq: vi.fn((a, b) => ({ type: "eq", a, b })),
+  and: vi.fn((...args: unknown[]) => args),
+  desc: vi.fn((col) => ({ type: "desc", col })),
+  sum: sumMock,
+}));
+
+vi.mock("../../src/logger.js", () => ({ default: { error: vi.fn() } }));
+
+import { getLeaderboard } from "../../src/utilities/leaderboard.js";
+import { drizzleDb } from "../../src/db/connector.js";
+
+describe("getLeaderboard", () => {
+  function makeChain(resolvedRows: any[]) {
+    const chain: any = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      groupBy: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue(resolvedRows),
+    };
+    return chain;
+  }
+
+  const noGuildClient = {
+    guilds: {
+      cache: new Map(),
+      fetch: vi.fn().mockRejectedValue(new Error("not in guild")),
+    },
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sumMock.mockReturnValue({ mapWith: () => "sum_hasPerformed" });
+  });
+
+  it("returns empty entries when no data exists", async () => {
+    (drizzleDb.select as any).mockReturnValue(makeChain([]));
+
+    const result = await getLeaderboard({
+      locationId: "guild-1",
+      discordClient: noGuildClient,
+    });
+
+    expect(result.locationId).toBe("guild-1");
+    expect(result.actionType).toBeNull();
+    expect(result.entries).toEqual([]);
+  });
+
+  it("returns ranked entries with anonymous labels when bot not in guild", async () => {
+    (drizzleDb.select as any).mockReturnValue(
+      makeChain([
+        { userId: "user-1", totalActions: 100 },
+        { userId: "user-2", totalActions: 50 },
+      ]),
+    );
+
+    const result = await getLeaderboard({
+      locationId: "guild-1",
+      discordClient: noGuildClient,
+    });
+
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries[0].rank).toBe(1);
+    expect(result.entries[0].userId).toBe("user-1");
+    expect(result.entries[0].displayName).toBeNull();
+    expect(result.entries[0].anonymousLabel).toHaveLength(4);
+    expect(result.entries[1].rank).toBe(2);
+  });
+
+  it("filters by actionType when provided", async () => {
+    (drizzleDb.select as any).mockReturnValue(
+      makeChain([{ userId: "user-1", totalActions: 20 }]),
+    );
+
+    const result = await getLeaderboard({
+      locationId: "guild-1",
+      actionType: "pet",
+      discordClient: noGuildClient,
+    });
+
+    expect(result.actionType).toBe("pet");
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].totalActions).toBe(20);
+  });
+
+  it("respects the limit parameter", async () => {
+    const chain = makeChain([]);
+    (drizzleDb.select as any).mockReturnValue(chain);
+
+    await getLeaderboard({
+      locationId: "guild-1",
+      limit: 5,
+      discordClient: noGuildClient,
+    });
+
+    expect(chain.limit).toHaveBeenCalledWith(5);
+  });
+
+  it("caps limit at 25", async () => {
+    const chain = makeChain([]);
+    (drizzleDb.select as any).mockReturnValue(chain);
+
+    await getLeaderboard({
+      locationId: "guild-1",
+      limit: 100,
+      discordClient: noGuildClient,
+    });
+
+    expect(chain.limit).toHaveBeenCalledWith(25);
+  });
+
+  it("defaults limit to 10", async () => {
+    const chain = makeChain([]);
+    (drizzleDb.select as any).mockReturnValue(chain);
+
+    await getLeaderboard({
+      locationId: "guild-1",
+      discordClient: noGuildClient,
+    });
+
+    expect(chain.limit).toHaveBeenCalledWith(10);
+  });
+
+  it("does not fetch display names when guild fetch fails", async () => {
+    const guildFetch = vi.fn().mockRejectedValue(new Error("not in guild"));
+    const client = {
+      guilds: { cache: new Map(), fetch: guildFetch },
+    } as any;
+
+    (drizzleDb.select as any).mockReturnValue(
+      makeChain([
+        { userId: "user-1", totalActions: 100 },
+        { userId: "user-2", totalActions: 50 },
+      ]),
+    );
+
+    const result = await getLeaderboard({
+      locationId: "guild-1",
+      discordClient: client,
+    });
+
+    expect(guildFetch).toHaveBeenCalledWith("guild-1");
+    expect(result.entries[0].displayName).toBeNull();
+    expect(result.entries[1].displayName).toBeNull();
+  });
+
+  it("uses display name when guild fetch succeeds", async () => {
+    const guildFetch = vi.fn().mockResolvedValue({
+      members: {
+        fetch: vi.fn().mockResolvedValue(
+          new Map([
+            [
+              "user-1",
+              {
+                displayName: "CoolDude",
+                user: { displayName: "notused" },
+              },
+            ],
+          ]),
+        ),
+      },
+    });
+    const client = {
+      guilds: { cache: new Map(), fetch: guildFetch },
+    } as any;
+
+    (drizzleDb.select as any).mockReturnValue(
+      makeChain([{ userId: "user-1", totalActions: 100 }]),
+    );
+
+    const result = await getLeaderboard({
+      locationId: "guild-1",
+      discordClient: client,
+    });
+
+    expect(result.entries[0].displayName).toBe("CoolDude");
+  });
+
+  it("falls back to user.displayName when member.displayName is missing", async () => {
+    const guildFetch = vi.fn().mockResolvedValue({
+      members: {
+        fetch: vi.fn().mockResolvedValue(
+          new Map([
+            [
+              "user-1",
+              {
+                displayName: null,
+                user: { displayName: "FallbackName" },
+              },
+            ],
+          ]),
+        ),
+      },
+    });
+    const client = {
+      guilds: { cache: new Map(), fetch: guildFetch },
+    } as any;
+
+    (drizzleDb.select as any).mockReturnValue(
+      makeChain([{ userId: "user-1", totalActions: 100 }]),
+    );
+
+    const result = await getLeaderboard({
+      locationId: "guild-1",
+      discordClient: client,
+    });
+
+    expect(result.entries[0].displayName).toBe("FallbackName");
+  });
+});

--- a/tests/utilities/leaderboard.test.ts
+++ b/tests/utilities/leaderboard.test.ts
@@ -343,7 +343,7 @@ describe("getLeaderboard", () => {
         return makeChain([{ userId: "user-1", totalActions: 100 }]);
       }
       return makeConsentChain([
-        { hashedUserId: "c6c289", displayName: "ConsentName" },
+        { hashedUserId: "c6c289e49e9c05b2", displayName: "ConsentName" },
       ]);
     });
 


### PR DESCRIPTION
## Summary
- Added leaderboards to the web dashboard (global, guild, and DM stats pages) and a `/leaderboard` Discord slash command
- Hovering action cards on global stats filters the leaderboard to that action
- Added leaderboard display name setting in User Settings — users can opt to show their name instead of appearing anonymous, defaults to Discord username
- Current user is highlighted with amber tint; up to 15 entries
- Privacy: display name consent is stored against a hashed user ID, keeping raw Discord IDs and display names in separate tables

## Test plan
- [ ] Leaderboard renders on global, guild, and DM stats pages
- [ ] Hovering action cards filters the leaderboard
- [ ] `/leaderboard` slash command works in Discord
- [ ] User Settings → Leaderboard Display toggle works
- [ ] Display name saves and appears on leaderboard
- [ ] Disabling consent reverts to anonymous label
- [ ] Anonymous labels show 6 hex chars (was 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)