### PR TITLE
feat: stats visualizations and UI improvements

### DIFF
--- a/apps/web/app/globalStats/page.tsx
+++ b/apps/web/app/globalStats/page.tsx
@@ -6,6 +6,7 @@ import StatsCard from "@/components/stats/stats-card";
 import { ActionTotals } from "@/types/stats";
 import StatsCardSimple from "@/components/stats/stats-card-simple";
 import Leaderboard from "@/components/leaderboard";
+import { DistributionChart } from "@/components/stats/distribution-chart";
 
 export default function GlobalStatsPage() {
   const { data, isLoading, error, refresh } = useGlobalStats();
@@ -44,6 +45,7 @@ export default function GlobalStatsPage() {
                   value={data.totalLocations}
                 />
               </div>
+
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                 {entries.map(([actionKey, totals]) => (
                   <StatsCard
@@ -62,12 +64,19 @@ export default function GlobalStatsPage() {
             </div>
           </div>
 
-          {/* Right: leaderboard (desktop) */}
-          <Leaderboard
-            locationId={null}
-            actionType={hoveredAction}
-            className="col-span-4 xl:col-span-1"
-          />
+          <div className="col-span-4 xl:col-span-1 flex flex-col gap-4">
+            <DistributionChart
+              totalsByAction={data.totalsByAction}
+              title="Global Action Distribution"
+              description="All actions performed globally across Discord"
+              metricLabel="Total Actions"
+            />
+            <Leaderboard
+              locationId={null}
+              actionType={hoveredAction}
+              className="w-full"
+            />
+          </div>
         </div>
       )}
 

--- a/apps/web/app/guildStats/[guildId]/page.tsx
+++ b/apps/web/app/guildStats/[guildId]/page.tsx
@@ -9,6 +9,7 @@ import { useBotGuilds } from "@/hooks/use-bot-guilds";
 import StatsCard from "@/components/stats/stats-card";
 import StatsCardSimple from "@/components/stats/stats-card-simple";
 import Leaderboard from "@/components/leaderboard";
+import { DistributionChart } from "@/components/stats/distribution-chart";
 
 export default function GuildStatsPage({
   params,
@@ -84,6 +85,7 @@ export default function GuildStatsPage({
               />
             </div>
 
+
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {entries.map(([actionKey, totals]) => (
                 <StatsCard
@@ -108,13 +110,20 @@ export default function GuildStatsPage({
           ) : null}
         </div>
 
-        {/* Right: leaderboard (desktop) */}
-        <Leaderboard
-          locationId={guildId}
-          actionType={hoveredAction}
-          className="col-span-4 xl:col-span-1"
-          context="guild"
-        />
+        <div className="col-span-4 xl:col-span-1 flex flex-col gap-4">
+          <DistributionChart
+            totalsByAction={data.totalsByAction}
+            title="Guild Action Distribution"
+            description="Distribution of actions in this server"
+            metricLabel="Guild Actions"
+          />
+          <Leaderboard
+            locationId={guildId}
+            actionType={hoveredAction}
+            context="guild"
+            className="w-full"
+          />
+        </div>
       </div>
     </main>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -77,7 +77,7 @@ export default function Home() {
             />
             <Button
               size="lg"
-              className={"bg-[#fff] hover:scale-105 hover:bg-[#fff]"}
+              className={"bg-[#fff] text-black border border-input dark:border-transparent hover:scale-105 hover:bg-[#fff]"}
               render={
                 <Link
                   href="https://github.com/RustedAperture/petbot"

--- a/apps/web/app/userStats/page.tsx
+++ b/apps/web/app/userStats/page.tsx
@@ -7,6 +7,7 @@ import { useGlobalStats } from "@/hooks/use-global-stats";
 import { type ActionTotals } from "@/types/stats";
 import StatsCard from "@/components/stats/stats-card";
 import StatsCardSimple from "@/components/stats/stats-card-simple";
+import { UserDistributionChart } from "@/components/stats/user-distribution-chart";
 
 export default function UserStatsPage() {
   const params = useSearchParams();
@@ -74,12 +75,14 @@ export default function UserStatsPage() {
           </div>
 
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <UserDistributionChart totalsByAction={data.totalsByAction} />
             {entries.map(([actionKey, totals]) => (
               <StatsCard
                 key={actionKey}
                 actionName={actionKey}
                 actionImageUrl={totals.imageUrl}
                 performedCount={totals.totalHasPerformed}
+                receivedCount={totals.totalHasReceived}
                 userCount={totals.totalUsers}
                 totalUniqueUsers={data.totalUniqueUsers}
                 totalActionsPerformed={data.totalActionsPerformed}

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -96,7 +96,7 @@ export default function Leaderboard({
               const label =
                 entry.displayName ?? `User #${entry.anonymousLabel}`;
               const isOutsideTopN = entry.isCurrentUser && entry.rank !== i + 1;
-              const maxActions = data.entries[0]?.totalActions ?? 1;
+              const maxActions = Math.max(data.entries[0]?.totalActions || 1, 1);
               const relativePercent = (entry.totalActions / maxActions) * 100;
 
               return (

--- a/apps/web/components/leaderboard.tsx
+++ b/apps/web/components/leaderboard.tsx
@@ -23,7 +23,7 @@ interface LeaderboardProps {
   context?: "guild";
 }
 
-const MAX_LIMIT = 15;
+const MAX_LIMIT = 10;
 
 function responsiveClass(index: number): string {
   if (index < 10) return "";
@@ -66,7 +66,7 @@ export default function Leaderboard({
   return (
     <Card
       className={cn(
-        "self-start pb-0 bg-linear-to-b from-primary/10 to-25% dark:from-primary/15",
+        "self-start pb-0 bg-linear-to-b from-primary/5 to-25% dark:from-primary/10",
         className,
       )}
     >
@@ -96,18 +96,28 @@ export default function Leaderboard({
               const label =
                 entry.displayName ?? `User #${entry.anonymousLabel}`;
               const isOutsideTopN = entry.isCurrentUser && entry.rank !== i + 1;
+              const maxActions = data.entries[0]?.totalActions ?? 1;
+              const relativePercent = (entry.totalActions / maxActions) * 100;
 
               return (
                 <React.Fragment key={`${entry.anonymousLabel}-${i}`}>
                   {isOutsideTopN && <Separator className="my-1" />}
                 <div
                   className={cn(
-                    "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
+                    "relative flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors overflow-hidden",
                     responsiveClass(i),
                     entry.isCurrentUser && "bg-amber-500/10",
                   )}
                 >
-                  <span className="w-5 text-center">
+                  <div
+                    className={cn(
+                      "absolute inset-y-0 left-0 bg-primary/10 dark:bg-primary/20 transition-all duration-500 pointer-events-none",
+                      entry.isCurrentUser && "bg-amber-500/15 dark:bg-amber-500/25",
+                    )}
+                    style={{ width: `${relativePercent}%` }}
+                  />
+
+                  <span className="relative z-10 w-5 text-center">
                     {entry.rank <= 3 ? (
                       rankEmojis[entry.rank - 1]
                     ) : (
@@ -119,7 +129,7 @@ export default function Leaderboard({
 
                   <span
                     className={cn(
-                      "flex-1 truncate",
+                      "relative z-10 flex-1 truncate",
                       entry.isCurrentUser && "font-medium text-amber-500",
                     )}
                   >
@@ -127,7 +137,7 @@ export default function Leaderboard({
                     {entry.isCurrentUser ? " (you)" : ""}
                   </span>
 
-                  <span className="font-mono text-xs text-muted-foreground tabular-nums">
+                  <span className="relative z-10 font-mono text-xs text-muted-foreground tabular-nums">
                     {entry.totalActions.toLocaleString()}
                   </span>
                 </div>

--- a/apps/web/components/stats/distribution-chart.tsx
+++ b/apps/web/components/stats/distribution-chart.tsx
@@ -97,9 +97,16 @@ export function DistributionChart({
                           <span className="text-muted-foreground capitalize">
                             {label}
                           </span>
-                          <span className="font-mono font-medium text-foreground tabular-nums">
-                            {d.count.toLocaleString()}
-                          </span>
+                          <div className="flex items-baseline gap-1">
+                            <span className="font-mono font-medium text-foreground tabular-nums">
+                              {d.count.toLocaleString()}
+                            </span>
+                            {metricLabel && (
+                              <span className="text-[10px] text-muted-foreground">
+                                {metricLabel.toLowerCase()}
+                              </span>
+                            )}
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/apps/web/components/stats/distribution-chart.tsx
+++ b/apps/web/components/stats/distribution-chart.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import * as React from "react";
+import { RadialBar, RadialBarChart } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+  CardFooter,
+} from "@/components/ui/card";
+import { type ActionTotals } from "@/types/stats";
+
+interface DistributionChartProps {
+  totalsByAction: Record<string, ActionTotals>;
+  title?: string;
+  description?: string;
+  metricLabel?: string;
+}
+
+const chartConfig = {
+  displayCount: {
+    label: "Actions",
+  },
+  pet: { label: "Pet", color: "var(--chart-2)" },
+  bite: { label: "Bite", color: "oklch(0.62 0.2 25)" },
+  hug: { label: "Hug", color: "oklch(0.65 0.18 145)" },
+  bonk: { label: "Bonk", color: "var(--chart-3)" },
+  squish: { label: "Squish", color: "var(--chart-1)" },
+  explode: { label: "Explode", color: "oklch(0.62 0.22 350)" },
+} satisfies ChartConfig;
+
+export function DistributionChart({
+  totalsByAction,
+  title = "Action Distribution",
+  description = "A breakdown of active interactions",
+}: DistributionChartProps) {
+  const chartData = React.useMemo(() => {
+    return Object.entries(totalsByAction)
+      .map(([actionKey, data]) => ({
+        action: actionKey,
+        count: data.totalHasPerformed,
+        displayCount: Math.log1p(data.totalHasPerformed),
+        fill: `var(--color-${actionKey})`,
+      }))
+      .filter((d) => d.count > 0)
+      .sort((a, b) => b.count - a.count);
+  }, [totalsByAction]);
+
+  const hasData = chartData.length > 0;
+
+  return (
+    <Card className="w-full bg-linear-to-b from-primary/5 to-25% dark:from-primary/10 flex flex-col">
+      <CardHeader className="items-center pb-0">
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex-1 pb-0 flex justify-center items-center min-h-[220px]">
+        {hasData ? (
+          <ChartContainer
+            config={chartConfig}
+            className="mx-auto aspect-square w-full max-w-[240px]"
+          >
+            <RadialBarChart
+              data={chartData}
+              startAngle={-90}
+              endAngle={380}
+              innerRadius={28}
+              outerRadius={100}
+            >
+              <ChartTooltip
+                cursor={false}
+                content={({ active, payload }) => {
+                  if (!active || !payload?.length) return null;
+                  const d = payload[0].payload as {
+                    action: string;
+                    count: number;
+                    fill: string;
+                  };
+                  const label =
+                    chartConfig[d.action as keyof typeof chartConfig]?.label ??
+                    d.action;
+                  return (
+                    <div className="grid min-w-32 items-start gap-1.5 rounded-xl bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-lg ring-1 ring-foreground/5 dark:ring-foreground/10">
+                      <div className="flex w-full items-center gap-2">
+                        <div
+                          className="h-2.5 w-1 shrink-0 rounded-[2px]"
+                          style={{ backgroundColor: d.fill }}
+                        />
+                        <div className="flex flex-1 justify-between items-center leading-none gap-4">
+                          <span className="text-muted-foreground capitalize">
+                            {label}
+                          </span>
+                          <span className="font-mono font-medium text-foreground tabular-nums">
+                            {d.count.toLocaleString()}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                }}
+              />
+              <RadialBar dataKey="displayCount" background />
+            </RadialBarChart>
+          </ChartContainer>
+        ) : (
+          <div className="flex flex-col items-center justify-center text-muted-foreground text-sm text-center">
+            No interactions recorded yet.
+          </div>
+        )}
+      </CardContent>
+      {hasData && (
+        <CardFooter className="flex flex-wrap gap-x-4 gap-y-1.5 pt-4 pb-4 justify-center">
+          {chartData.map((d) => {
+            const config = chartConfig[d.action as keyof typeof chartConfig];
+            const label = config?.label ?? d.action;
+            const color = "color" in (config ?? {}) ? (config as { color: string }).color : d.fill;
+            return (
+              <div
+                key={d.action}
+                className="flex items-center gap-2 text-xs"
+              >
+                <div
+                  className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                  style={{ backgroundColor: color }}
+                />
+                <span className="text-muted-foreground">{label}</span>
+              </div>
+            );
+          })}
+        </CardFooter>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/components/stats/distribution-chart.tsx
+++ b/apps/web/components/stats/distribution-chart.tsx
@@ -40,6 +40,7 @@ export function DistributionChart({
   totalsByAction,
   title = "Action Distribution",
   description = "A breakdown of active interactions",
+  metricLabel,
 }: DistributionChartProps) {
   const chartData = React.useMemo(() => {
     return Object.entries(totalsByAction)

--- a/apps/web/components/stats/stats-card.tsx
+++ b/apps/web/components/stats/stats-card.tsx
@@ -19,6 +19,7 @@ interface StatsCardProps {
   actionName: string;
   actionImageUrl: string;
   performedCount: number;
+  receivedCount?: number;
   userCount: number;
   totalUniqueUsers: number;
   totalActionsPerformed: number;
@@ -33,6 +34,7 @@ export default function StatsCard({
   actionName,
   actionImageUrl,
   performedCount,
+  receivedCount,
   userCount,
   totalUniqueUsers,
   totalActionsPerformed,
@@ -153,6 +155,19 @@ export default function StatsCard({
                 />
               </div>
             </div>
+            {receivedCount !== undefined && (
+              <div className="flex gap-1 flex-wrap">
+                <p className="shrink">
+                  <b>Received:</b>
+                </p>
+                <div className="flex justify-between grow">
+                  <NativeCounterUp
+                    value={receivedCount}
+                    className="font-normal"
+                  />
+                </div>
+              </div>
+            )}
             {!hideUserCount && (
               <div className="flex gap-1 flex-wrap">
                 <p className="shrink">

--- a/apps/web/components/stats/user-distribution-chart.tsx
+++ b/apps/web/components/stats/user-distribution-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import {
   ChartContainer,
   ChartLegend,
@@ -36,7 +36,10 @@ export function UserDistributionChart({
   totalsByAction,
 }: UserDistributionChartProps) {
   const chartData = Object.entries(totalsByAction)
-    .filter(([, totals]) => totals.totalHasPerformed > 0)
+    .filter(
+      ([, totals]) =>
+        totals.totalHasPerformed > 0 || (totals.totalHasReceived ?? 0) > 0,
+    )
     .map(([actionKey, totals]) => ({
       action: actionKey.charAt(0).toUpperCase() + actionKey.slice(1),
       performed: totals.totalHasPerformed,

--- a/apps/web/components/stats/user-distribution-chart.tsx
+++ b/apps/web/components/stats/user-distribution-chart.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { type ActionTotals } from "@/types/stats";
+
+interface UserDistributionChartProps {
+  totalsByAction: Record<string, ActionTotals>;
+}
+
+const chartConfig = {
+  displayPerformed: {
+    label: "Performed",
+    color: "var(--chart-2)",
+  },
+  displayReceived: {
+    label: "Received",
+    color: "var(--chart-1)",
+  },
+} satisfies ChartConfig;
+
+export function UserDistributionChart({
+  totalsByAction,
+}: UserDistributionChartProps) {
+  const chartData = Object.entries(totalsByAction)
+    .filter(([, totals]) => totals.totalHasPerformed > 0)
+    .map(([actionKey, totals]) => ({
+      action: actionKey.charAt(0).toUpperCase() + actionKey.slice(1),
+      performed: totals.totalHasPerformed,
+      received: totals.totalHasReceived ?? 0,
+      // log1p-scaled values drive bar height so skewed data stays readable
+      displayPerformed: Math.log1p(totals.totalHasPerformed),
+      displayReceived: Math.log1p(totals.totalHasReceived ?? 0),
+    }));
+
+  return (
+    <Card className="w-full bg-linear-to-b from-primary/5 to-25% dark:from-primary/10 flex flex-col">
+      <CardHeader>
+        <CardTitle>Interaction Distribution</CardTitle>
+        <CardDescription>
+          Performed vs. received across all action types
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex-1">
+        <ChartContainer config={chartConfig} className="h-full min-h-[220px] w-full">
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 4, right: 0, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid horizontal={false} className="stroke-border/40" />
+            <YAxis
+              dataKey="action"
+              type="category"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              tick={{ className: "fill-foreground font-medium", fontSize: 12 }}
+              width={56}
+            />
+            <XAxis type="number" hide domain={[0, "dataMax"]} />
+            <ChartTooltip
+              cursor={false}
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null;
+                const d = payload[0].payload as {
+                  action: string;
+                  performed: number;
+                  received: number;
+                };
+                return (
+                  <div className="grid min-w-36 items-start gap-1.5 rounded-xl bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-lg ring-1 ring-foreground/5 dark:ring-foreground/10">
+                    <span className="font-medium text-foreground mb-0.5">
+                      {d.action}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <div className="h-2.5 w-1 shrink-0 rounded-[2px] bg-[var(--color-displayPerformed)]" />
+                      <span className="text-muted-foreground flex-1">Performed</span>
+                      <span className="font-mono font-medium text-foreground tabular-nums">
+                        {d.performed.toLocaleString()}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <div className="h-2.5 w-1 shrink-0 rounded-[2px] bg-[var(--color-displayReceived)]" />
+                      <span className="text-muted-foreground flex-1">Received</span>
+                      <span className="font-mono font-medium text-foreground tabular-nums">
+                        {d.received.toLocaleString()}
+                      </span>
+                    </div>
+                  </div>
+                );
+              }}
+            />
+            <ChartLegend content={<ChartLegendContent />} />
+            <Bar
+              dataKey="displayPerformed"
+              fill="var(--color-displayPerformed)"
+              radius={4}
+            />
+            <Bar
+              dataKey="displayReceived"
+              fill="var(--color-displayReceived)"
+              radius={4}
+            />
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "8.7.0",
+  "version": "8.8.0",
   "private": true,
   "engines": {
     "node": ">=24",

--- a/apps/web/types/stats.ts
+++ b/apps/web/types/stats.ts
@@ -1,5 +1,6 @@
 export type ActionTotals = {
   totalHasPerformed: number;
+  totalHasReceived?: number;
   totalUsers: number;
   imageUrl: string;
   images?: string[];

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+## v8.8.0 - Jun 02, 2026
+
+### What You'll Notice
+
+- **New User Stats Chart:** Added a new grouped horizontal bar chart to the user stats page, letting you directly compare how many actions you've performed vs. how many you've received.
+- **Redesigned Distribution Chart:** The global and guild action distribution chart is now a sleek radial ring chart with log-scaling to visualize highly skewed data.
+- **Dashboard Layout Polish:** Reorganized the stats dashboards by moving the distribution chart into the right-hand sidebar above the leaderboard.
+- Reduced the leaderboard size from Top 15 to Top 10.
+- Improved gradient matching and UI sizing across all stats components.
+
+### Under the Hood
+
+- **API Updates:** The `/api/stats` backend route now properly aggregates and returns both `totalHasPerformed` and `totalHasReceived` from the database.
+- Chart components have been refactored to consume the new dual-aggregation data format.
+
 ## v8.7.0 - May 28, 2026
 
 ### What You'll Notice

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@
 - **API Updates:** The `/api/stats` backend route now properly aggregates and returns both `totalHasPerformed` and `totalHasReceived` from the database.
 - Chart components have been refactored to consume the new dual-aggregation data format.
 
+### Fixes
+
+- Fixed the GitHub link button on the homepage being invisible in light mode by improving its contrast and adding a subtle border.
+
 ## v8.7.0 - May 28, 2026
 
 ### What You'll Notice

--- a/drizzle/20260218003401_initial/snapshot.json
+++ b/drizzle/20260218003401_initial/snapshot.json
@@ -241,36 +241,28 @@
       "table": "actionData"
     },
     {
-      "columns": [
-        "name"
-      ],
+      "columns": ["name"],
       "nameExplicit": true,
       "name": "SequelizeMeta_pk",
       "table": "SequelizeMeta",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": true,
       "name": "actionData_pk",
       "table": "actionData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": true,
       "name": "botData_pk",
       "table": "botData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": true,
       "name": "userSessions_pk",
       "table": "userSessions",

--- a/drizzle/20260218003421_change_date_to_text/snapshot.json
+++ b/drizzle/20260218003421_change_date_to_text/snapshot.json
@@ -2,9 +2,7 @@
   "version": "7",
   "dialect": "sqlite",
   "id": "cf531141-7818-47af-b0fc-925e25d0f7e6",
-  "prevIds": [
-    "00000000-0000-0000-0000-000000000000"
-  ],
+  "prevIds": ["00000000-0000-0000-0000-000000000000"],
   "ddl": [
     {
       "name": "actionData",
@@ -243,36 +241,28 @@
       "table": "userSessions"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "actionData_pk",
       "table": "actionData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "botData_pk",
       "table": "botData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "name"
-      ],
+      "columns": ["name"],
       "nameExplicit": false,
       "name": "SequelizeMeta_pk",
       "table": "SequelizeMeta",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": false,
       "name": "userSessions_pk",
       "table": "userSessions",

--- a/drizzle/20260218003529_normalize-timestamps/snapshot.json
+++ b/drizzle/20260218003529_normalize-timestamps/snapshot.json
@@ -1,8 +1,6 @@
 {
   "id": "c77352a1-a827-4af6-b0a2-8ae680bffaed",
-  "prevIds": [
-    "cf531141-7818-47af-b0fc-925e25d0f7e6"
-  ],
+  "prevIds": ["cf531141-7818-47af-b0fc-925e25d0f7e6"],
   "version": "7",
   "dialect": "sqlite",
   "ddl": [
@@ -243,36 +241,28 @@
       "table": "userSessions"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "actionData_pk",
       "table": "actionData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "botData_pk",
       "table": "botData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "name"
-      ],
+      "columns": ["name"],
       "nameExplicit": false,
       "name": "SequelizeMeta_pk",
       "table": "SequelizeMeta",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": false,
       "name": "userSessions_pk",
       "table": "userSessions",

--- a/drizzle/20260218020927_json_to_text/snapshot.json
+++ b/drizzle/20260218020927_json_to_text/snapshot.json
@@ -2,9 +2,7 @@
   "version": "7",
   "dialect": "sqlite",
   "id": "b39f987a-4dae-4cd6-998f-ebb5a6bbed28",
-  "prevIds": [
-    "c77352a1-a827-4af6-b0a2-8ae680bffaed"
-  ],
+  "prevIds": ["c77352a1-a827-4af6-b0a2-8ae680bffaed"],
   "ddl": [
     {
       "name": "actionData",
@@ -243,36 +241,28 @@
       "table": "userSessions"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "actionData_pk",
       "table": "actionData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "botData_pk",
       "table": "botData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "name"
-      ],
+      "columns": ["name"],
       "nameExplicit": false,
       "name": "SequelizeMeta_pk",
       "table": "SequelizeMeta",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": false,
       "name": "userSessions_pk",
       "table": "userSessions",

--- a/drizzle/20260305233323_optOut/snapshot.json
+++ b/drizzle/20260305233323_optOut/snapshot.json
@@ -2,9 +2,7 @@
   "version": "7",
   "dialect": "sqlite",
   "id": "9a8d7c9e-25c2-401a-9981-eebbd864de66",
-  "prevIds": [
-    "b39f987a-4dae-4cd6-998f-ebb5a6bbed28"
-  ],
+  "prevIds": ["b39f987a-4dae-4cd6-998f-ebb5a6bbed28"],
   "ddl": [
     {
       "name": "actionData",
@@ -277,45 +275,35 @@
       "table": "userSessions"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "actionData_pk",
       "table": "actionData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "botData_pk",
       "table": "botData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": false,
       "name": "optOut_pk",
       "table": "optOut",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "name"
-      ],
+      "columns": ["name"],
       "nameExplicit": false,
       "name": "SequelizeMeta_pk",
       "table": "SequelizeMeta",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": false,
       "name": "userSessions_pk",
       "table": "userSessions",

--- a/drizzle/20260318043126_restricted/snapshot.json
+++ b/drizzle/20260318043126_restricted/snapshot.json
@@ -2,9 +2,7 @@
   "version": "7",
   "dialect": "sqlite",
   "id": "2a9532c8-81c6-4b94-b792-86ca3ca44309",
-  "prevIds": [
-    "9a8d7c9e-25c2-401a-9981-eebbd864de66"
-  ],
+  "prevIds": ["9a8d7c9e-25c2-401a-9981-eebbd864de66"],
   "ddl": [
     {
       "name": "actionData",
@@ -287,45 +285,35 @@
       "table": "userSessions"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "actionData_pk",
       "table": "actionData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "botData_pk",
       "table": "botData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": false,
       "name": "optOut_pk",
       "table": "optOut",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "name"
-      ],
+      "columns": ["name"],
       "nameExplicit": false,
       "name": "SequelizeMeta_pk",
       "table": "SequelizeMeta",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": false,
       "name": "userSessions_pk",
       "table": "userSessions",

--- a/drizzle/20260528222821_equal_human_torch/snapshot.json
+++ b/drizzle/20260528222821_equal_human_torch/snapshot.json
@@ -2,9 +2,7 @@
   "version": "7",
   "dialect": "sqlite",
   "id": "873bb927-e08e-4363-a10b-fb7d9752b35e",
-  "prevIds": [
-    "2a9532c8-81c6-4b94-b792-86ca3ca44309"
-  ],
+  "prevIds": ["2a9532c8-81c6-4b94-b792-86ca3ca44309"],
   "ddl": [
     {
       "name": "actionData",
@@ -331,54 +329,42 @@
       "table": "userSessions"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "actionData_pk",
       "table": "actionData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "botData_pk",
       "table": "botData",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "hashed_user_id"
-      ],
+      "columns": ["hashed_user_id"],
       "nameExplicit": false,
       "name": "leaderboardConsent_pk",
       "table": "leaderboardConsent",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": false,
       "name": "optOut_pk",
       "table": "optOut",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "name"
-      ],
+      "columns": ["name"],
       "nameExplicit": false,
       "name": "SequelizeMeta_pk",
       "table": "SequelizeMeta",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "user_id"
-      ],
+      "columns": ["user_id"],
       "nameExplicit": false,
       "name": "userSessions_pk",
       "table": "userSessions",

--- a/eslint.config.base.js
+++ b/eslint.config.base.js
@@ -30,7 +30,11 @@ export const tsRules = {
   "no-unused-vars": "off",
   "@typescript-eslint/no-unused-vars": [
     "error",
-    { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+    {
+      argsIgnorePattern: "^_",
+      varsIgnorePattern: "^_",
+      caughtErrorsIgnorePattern: "^_",
+    },
   ],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "petbot",
-  "version": "8.7.0",
+  "version": "8.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "petbot",
-      "version": "8.7.0",
+      "version": "8.8.0",
       "license": "ISC",
       "workspaces": [
         "apps/web"
@@ -47,7 +47,7 @@
       }
     },
     "apps/web": {
-      "version": "8.7.0",
+      "version": "8.8.0",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petbot",
-  "version": "8.7.0",
+  "version": "8.8.0",
   "description": "",
   "type": "module",
   "packageManager": "npm@11.16.0",

--- a/src/http/routes/stats.ts
+++ b/src/http/routes/stats.ts
@@ -8,16 +8,18 @@ import logger from "../../logger.js";
 type ActionAggregate = {
   actionType: string;
   totalHasPerformed: unknown;
+  totalHasReceived: unknown;
   totalUsers: unknown;
 };
 
 async function getActionAggregates(
   whereClauses: unknown[] = [],
-): Promise<Record<string, { totalHasPerformed: number; totalUsers: number }>> {
+): Promise<Record<string, { totalHasPerformed: number; totalHasReceived: number; totalUsers: number }>> {
   let query: any = drizzleDb
     .select({
       actionType: actionData.actionType,
       totalHasPerformed: sql`SUM(${actionData.hasPerformed})`,
+      totalHasReceived: sql`SUM(${actionData.hasReceived})`,
       totalUsers: sql`COUNT(DISTINCT CASE WHEN ${actionData.hasPerformed} > 0 THEN ${actionData.userId} END)`,
     })
     .from(actionData);
@@ -28,10 +30,11 @@ async function getActionAggregates(
 
   const rows: ActionAggregate[] = await query.groupBy(actionData.actionType);
   return rows.reduce<
-    Record<string, { totalHasPerformed: number; totalUsers: number }>
+    Record<string, { totalHasPerformed: number; totalHasReceived: number; totalUsers: number }>
   >((acc, row) => {
     acc[row.actionType] = {
       totalHasPerformed: Number(row.totalHasPerformed ?? 0),
+      totalHasReceived: Number(row.totalHasReceived ?? 0),
       totalUsers: Number(row.totalUsers ?? 0),
     };
     return acc;
@@ -100,6 +103,7 @@ export default async function statsHandler(
         string,
         {
           totalHasPerformed: number;
+          totalHasReceived: number;
           totalUsers: number;
           imageUrl?: string;
           images?: string[];
@@ -141,10 +145,12 @@ export default async function statsHandler(
       actionKinds.forEach((k) => {
         const aggregate = aggregatesByAction[k] ?? {
           totalHasPerformed: 0,
+          totalHasReceived: 0,
           totalUsers: 0,
         };
         totalsByAction[k] = {
           totalHasPerformed: aggregate.totalHasPerformed,
+          totalHasReceived: aggregate.totalHasReceived,
           totalUsers: aggregate.totalUsers,
           imageUrl: ACTIONS[k as keyof typeof ACTIONS]?.defaultImage ?? null,
           ...(imagesByAction[k] ? { images: imagesByAction[k] } : {}),
@@ -254,6 +260,7 @@ export default async function statsHandler(
       string,
       {
         totalHasPerformed: number;
+        totalHasReceived: number;
         totalUsers: number;
         imageUrl?: string;
         images?: string[];
@@ -263,10 +270,12 @@ export default async function statsHandler(
     actionKinds.forEach((k) => {
       const aggregate = aggregatesByAction[k] ?? {
         totalHasPerformed: 0,
+        totalHasReceived: 0,
         totalUsers: 0,
       };
       totalsByAction[k] = {
         totalHasPerformed: aggregate.totalHasPerformed,
+        totalHasReceived: aggregate.totalHasReceived,
         totalUsers: aggregate.totalUsers,
         imageUrl: ACTIONS[k as keyof typeof ACTIONS]?.defaultImage ?? null,
       };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,12 +40,7 @@
     "sourceMap": true,
     "declaration": false
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "tests/**/*.ts",
-    "tests/**/*.tsx"
-  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"],
   "exclude": [
     "node_modules",
     "dist",

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -7,14 +7,6 @@
     "outDir": "dist",
     "noEmit": false
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "**/*.tsx",
-    "tests",
-    "apps/web",
-    "node_modules",
-    "dist"
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.tsx", "tests", "apps/web", "node_modules", "dist"]
 }


### PR DESCRIPTION
## Changes
- **New User Stats Chart:** Added a new grouped horizontal bar chart to the user stats page, letting you directly compare how many actions you've performed vs. how many you've received.
- **Redesigned Distribution Chart:** The global and guild action distribution chart is now a sleek radial ring chart with log-scaling to visualize highly skewed data.
- **Dashboard Layout Polish:** Reorganized the stats dashboards by moving the distribution chart into the right-hand sidebar above the leaderboard.
- Reduced the leaderboard size from Top 15 to Top 10.
- Improved gradient matching and UI sizing across all stats components.
- **API Updates:** The `/api/stats` backend route now properly aggregates and returns both `totalHasPerformed` and `totalHasReceived` from the database.
- Bumps version to 8.8.0